### PR TITLE
AttributeError on THZTime update when translation_key is set

### DIFF
--- a/custom_components/thz/base_entity.py
+++ b/custom_components/thz/base_entity.py
@@ -55,6 +55,7 @@ class THZBaseEntity(Entity):
         self._device = device
         self._device_id = device_id
         self._attr_icon = icon or "mdi:eye"
+        self._entity_name = name  # always available for logging / fallback
 
         # Per Home Assistant documentation, has_entity_name=True is MANDATORY for new integrations.
         # See: https://developers.home-assistant.io/docs/core/entity/#entity-naming

--- a/custom_components/thz/time.py
+++ b/custom_components/thz/time.py
@@ -219,7 +219,7 @@ class THZTime(THZBaseEntity, TimeEntity):
 
         Always return the entity name since time entities don't use translation keys.
         """
-        return self._attr_name
+        return getattr(self, '_attr_name', self._entity_name)
 
     @property
     def native_value(self):
@@ -242,7 +242,7 @@ class THZTime(THZBaseEntity, TimeEntity):
         # Time values are stored as single bytes (0-95 quarters)
         num = value_bytes[0]
         self._attr_native_value = quarters_to_time(num)
-        _LOGGER.debug("Updated time %s: %s quarters -> %s", self._attr_name, num, self._attr_native_value)
+        _LOGGER.debug("Updated time %s: %s quarters -> %s", self._entity_name, num, self._attr_native_value)
 
     async def async_set_native_value(self, value: str):
         """Set new value for the time."""
@@ -254,7 +254,7 @@ class THZTime(THZBaseEntity, TimeEntity):
             t_value = time(hour, minute)
 
         num = time_to_quarters(t_value)
-        _LOGGER.debug("Setting time %s to %s (%s quarters)", self._attr_name, t_value, num)
+        _LOGGER.debug("Setting time %s to %s (%s quarters)", self._entity_name, t_value, num)
 
         # Write as 2 bytes to match the protocol's read format (offset=4, length=2)
         # even though only the first byte contains the meaningful time value (0-95 quarters).


### PR DESCRIPTION
THZBaseEntity intentionally omits setting _attr_name when a translation_key is provided (to avoid blocking HA's translation lookup). THZTime.name and its async_update / async_set_native_value debug logs unconditionally accessed self._attr_name, causing:

  AttributeError: 'THZTime' object has no attribute '__attr_name'

Fix by storing the raw name in self._entity_name in THZBaseEntity.__init__ (always set, regardless of the translation path) and updating THZTime to:
- use getattr(self, '_attr_name', self._entity_name) in the name property
- reference self._entity_name in both debug log calls