### PR TITLE
Disable readings for LWZ 403 SOL running firmware version 4.39

### DIFF
--- a/custom_components/thz/register_maps/register_map_439.py
+++ b/custom_components/thz/register_maps/register_map_439.py
@@ -1,0 +1,82 @@
+"""Register map overrides for THZ firmware 4.39.
+
+Overrides pxxFB entries from register_map_all that are not available on all
+4.39 hardware variants (e.g. LWZ 403 SOL).  The three sensors below are
+listed with decode_type "disabled" so that:
+
+  1. The additive merge in RegisterMapManager replaces the register_map_all
+     entries (same name → base entries filtered out, disabled stubs inserted).
+  2. The sensor creation loop in sensor.py skips entries with decode_type
+     "disabled", so no entity is created and no "payload too short" warning
+     is logged.
+
+Affected sensors and why they are disabled:
+  - flowRate:       nibble offset 110 → byte 55+  (payload is 55 bytes)
+  - p_HCw:          nibble offset 114 → byte 57+
+  - humidityAirOut: nibble offset 154 → byte 77+
+"""
+
+REGISTER_MAP = {
+    "firmware": "439",
+    "pxxFB": [
+        ("outsideTemp:", 8, 4, "hex2int", 10),
+        ("flowTemp:", 12, 4, "hex2int", 10),
+        ("returnTemp:", 16, 4, "hex2int", 10),
+        ("hotGasTemp:", 20, 4, "hex2int", 10),
+        ("dhwTemp:", 24, 4, "hex2int", 10),
+        ("flowTempHC2:", 28, 4, "hex2int", 10),
+        ("evaporatorTemp:", 36, 4, "hex2int", 10),
+        ("condenserTemp:", 40, 4, "hex2int", 10),
+        ("mixerOpen:", 45, 1, "bit0", 1),
+        ("mixerClosed:", 45, 1, "bit1", 1),
+        ("heatPipeValve:", 45, 1, "bit2", 1),
+        ("diverterValve:", 45, 1, "bit3", 1),
+        ("dhwPump:", 44, 1, "bit0", 1),
+        ("heatingCircuitPump:", 44, 1, "bit1", 1),
+        ("solarPump:", 44, 1, "bit3", 1),
+        ("compressor:", 47, 1, "bit3", 1),
+        ("boosterStage3:", 46, 1, "bit0", 1),
+        ("boosterStage2:", 46, 1, "bit1", 1),
+        ("boosterStage1:", 46, 1, "bit2", 1),
+        ("highPressureSensor:", 49, 1, "nbit0", 1),
+        ("lowPressureSensor:", 49, 1, "nbit1", 1),
+        ("evaporatorIceMonitor:", 49, 1, "bit2", 1),
+        ("signalAnode:", 49, 1, "bit3", 1),
+        ("evuRelease:", 48, 1, "bit0", 1),
+        ("ovenFireplace:", 48, 1, "bit1", 1),
+        ("STB:", 48, 1, "bit2", 1),
+        ("outputVentilatorPower:", 50, 4, "hex", 10),
+        ("inputVentilatorPower:", 54, 4, "hex", 10),
+        ("mainVentilatorPower:", 58, 4, "hex", 10),
+        ("outputVentilatorSpeed:", 62, 4, "hex", 1),
+        ("inputVentilatorSpeed:", 66, 4, "hex", 1),
+        ("mainVentilatorSpeed:", 70, 4, "hex", 1),
+        ("outside_tempFiltered:", 74, 4, "hex2int", 10),
+        ("relHumidity:", 78, 4, "hex2int", 10),
+        ("dewPoint:", 82, 4, "hex2int", 10),
+        ("P_Nd:", 86, 4, "hex2int", 100),
+        ("P_Hd:", 90, 4, "hex2int", 100),
+        ("actualPower_Qc:", 94, 8, "esp_mant", 1),
+        ("actualPower_Pel:", 102, 8, "esp_mant", 1),
+        ("collectorTemp:", 4, 4, "hex2int", 10),
+        ("insideTemp:", 32, 4, "hex2int", 10),
+        (
+            "windowOpen:",
+            47,
+            1,
+            "bit2",
+            1,
+        ),  # board X18-1 clamp X4-FA (FensterAuf): window open - signal out 230V
+        (
+            "quickAirVent:",
+            48,
+            1,
+            "bit3",
+            1,
+        ),  # board X15-8 clamp X4-SL (SchnellLüftung): quickAirVent - signal in 230V
+        # Disabled: payload only 55 bytes on LWZ 403 SOL / firmware 4.39
+        ("flowRate:", 110, 4, "disabled", 100),
+        ("p_HCw:", 114, 4, "disabled", 100),
+        ("humidityAirOut:", 154, 4, "disabled", 100),
+    ],
+}

--- a/custom_components/thz/register_maps/register_map_manager.py
+++ b/custom_components/thz/register_maps/register_map_manager.py
@@ -15,6 +15,7 @@ from . import (
     register_map_206,  # noqa: F401
     register_map_214,  # noqa: F401
     register_map_214j,  # noqa: F401
+    register_map_439,  # noqa: F401
     register_map_all,  # noqa: F401
     write_map_206,  # noqa: F401
     write_map_214,  # noqa: F401
@@ -49,11 +50,11 @@ FIRMWARE_MAPS = {
     },
     "439technician": {
         "write": ["write_map_439_539", "write_map_439", "write_map_X39tech"],
-        "read": ["readings_map_439"],
+        "read": ["readings_map_439", "register_map_439"],
     },
     "439": {
         "write": ["write_map_439_539", "write_map_439"],
-        "read": ["readings_map_439"],
+        "read": ["readings_map_439", "register_map_439"],
     },
     # default fallback is treated as 539-like
     "default": {

--- a/custom_components/thz/sensor.py
+++ b/custom_components/thz/sensor.py
@@ -78,6 +78,9 @@ async def async_setup_entry(
         block_hex = block.removeprefix("pxx")  # Remove "pxx" prefix
         block_bytes = bytes.fromhex(block_hex)
         for name, offset, length, decode_type, factor in entries:
+            # Skip sensors explicitly disabled in firmware-specific register maps
+            if decode_type == "disabled":
+                continue
             # Strip whitespace and trailing colons from sensor name
             sensor_name = name.strip().rstrip(':')
 


### PR DESCRIPTION
- Add a handler for "disabled" registers in `sensor.py`
- Disable `flowRate`, `p_HCw` and `humidityAirOut` for firmware version 4.39

I get these log messages all the time:
```
[custom_components.thz.sensor] Payload too short for sensor flowRate: expected at least 57 bytes, got 55
[custom_components.thz.sensor] Payload too short for sensor p_HCw: expected at least 59 bytes, got 55
[custom_components.thz.sensor] Payload too short for sensor humidityAirOut: expected at least 79 bytes, got 55
``` 
Thinking back to my FHEM days, I can't recall those 3 values being present on my LWZ 403 SOL, so I think my model actually doesn't support those. I don't think my LWZ even has a sensor for humidityAirOut (its about 10 years old and cannot cool down, so it makes sense). 

I think this should be a model-related disablement, but since the current code base apparently has no way to disable individual readings based on the detected model (in my case: LWZ 403 SOL running 4.39), disable these readings for that firmware version.

Let me know if that doesn't work for you.