### PR TITLE
Add parameter backup/restore and real-time clock handling

### DIFF
--- a/custom_components/thz/__init__.py
+++ b/custom_components/thz/__init__.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
+import json
+import os
+from datetime import datetime, timedelta, time as dt_time
 import logging
+from typing import Any
 
 import voluptuous as vol
 
@@ -17,7 +20,9 @@ from homeassistant.core import (
 )
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import (
     DEFAULT_UPDATE_INTERVAL,
@@ -27,11 +32,36 @@ from .const import (
     should_hide_entity_by_default,
 )
 from .thz_device import THZDevice
+from .time import quarters_to_time, time_to_quarters
+from .value_codec import THZValueCodec
 
 _LOGGER = logging.getLogger(__name__)
 
 # Hex dump formatting constants
 BYTES_PER_HEX_LINE = 16  # Number of bytes to display per line in hex dumps
+
+# Parameter backup/restore constants
+BACKUP_SUBDIR = "thz_backups"
+# Register types that hold a persistent, restorable value. "button" is a
+# one-shot action with no state, and "ptime" is a legacy/unused type not
+# consumed by any current platform, so neither is backed up.
+_RESTORABLE_REGISTER_TYPES = {"number", "switch", "select", "time", "schedule"}
+
+# The device's real-time clock is exposed as five plain "pclean" registers
+# (day/month/year/hour/minute) that no platform claims as an entity, NOT as
+# a "time"-typed register. They are handled specially by backup/restore/the
+# periodic clock check below rather than as ordinary numeric parameters:
+# restoring an old backed-up clock value would set the heat pump's clock
+# back to whenever the backup was taken, and pClockYear's declared min/max
+# ("12".."20") is a stale bound that would otherwise get a real year like
+# 26 clamped down to 20.
+_CLOCK_REGISTER_NAMES = (
+    "pClockYear", "pClockMonth", "pClockDay", "pClockHour", "pClockMinutes",
+)
+# Device clock has no seconds field, so a little rounding slop is expected;
+# only flag/act on drift beyond these thresholds.
+_CLOCK_DRIFT_WARN_SECONDS = 60  # periodic check: log + optionally auto-correct
+_CLOCK_DRIFT_BACKUP_SECONDS = 3600  # backup: always auto-correct past this
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -172,6 +202,22 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         "unsupported_blocks": unsupported_blocks,
     }
 
+    # Periodic clock-drift check (independent of per-entity polling of the
+    # individual pClock* registers — see _async_check_and_maybe_sync_clock).
+    # Always runs so drift is logged; only writes a correction back to the
+    # device when the "auto_sync_clock" option is enabled.
+    async def _periodic_clock_check(_now=None) -> None:
+        try:
+            await _async_check_and_maybe_sync_clock(
+                hass, config_entry, device, write_manager
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("THZ periodic clock check failed: %s", err)
+
+    hass.data[DOMAIN][config_entry.entry_id]["unsub_clock_check"] = (
+        async_track_time_interval(hass, _periodic_clock_check, timedelta(minutes=15))
+    )
+
     # Forward setup to platforms
     await hass.config_entries.async_forward_entry_setups(
         config_entry,
@@ -267,6 +313,199 @@ async def async_refresh_block(
     if not found:
         _LOGGER.warning("async_refresh_block: block '%s' not found in any coordinator", normalized)
     return found
+
+
+# ---------------------------------------------------------------------------
+# Parameter backup/restore helpers
+# ---------------------------------------------------------------------------
+
+def _backups_dir(hass: HomeAssistant) -> str:
+    """Return the on-disk path of the parameter backups directory.
+
+    This lives inside the HA config directory (``config/thz_backups``), so
+    it is automatically swept up by Home Assistant's own Backup feature —
+    creating an HA backup backs these files up too, and restoring one
+    brings them back, with no extra steps.
+    """
+    return hass.config.path(BACKUP_SUBDIR)
+
+
+def _sanitize_label(label: str | None) -> str:
+    """Turn a user-supplied label into a safe filename suffix."""
+    if not label:
+        return ""
+    safe = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in label.strip())
+    safe = safe.strip("_")
+    return f"_{safe}" if safe else ""
+
+
+def _parse_hhmm(value: str | None) -> dt_time | None:
+    """Parse an ``"HH:MM"`` string (as stored in a backup) to a time, or None."""
+    if not value:
+        return None
+    hour, minute = map(int, value.split(":"))
+    return dt_time(hour, minute)
+
+
+def _resolve_entry_data(
+    hass: HomeAssistant, requested_entry_id: str | None
+) -> tuple[dict | None, dict | None]:
+    """Resolve the target THZ config entry's data dict.
+
+    Mirrors the entry-lookup pattern used by the other THZ services. Returns
+    ``(entry_data, error_response)`` — exactly one of the two is not None.
+    """
+    available_entries: dict[str, dict] = {
+        eid: ed
+        for eid, ed in hass.data.get(DOMAIN, {}).items()
+        if isinstance(ed, dict) and "device" in ed
+    }
+    if requested_entry_id:
+        entry_data = available_entries.get(requested_entry_id)
+        if entry_data is None:
+            return None, {
+                "success": False,
+                "error": f"No THZ entry found for entry_id '{requested_entry_id}'",
+            }
+        return entry_data, None
+    if len(available_entries) > 1:
+        return None, {
+            "success": False,
+            "error": (
+                "Multiple THZ config entries found. "
+                "Provide 'entry_id' to target a specific device."
+            ),
+        }
+    if available_entries:
+        return next(iter(available_entries.values())), None
+    return None, {"success": False, "error": "THZ device not initialised"}
+
+
+async def _async_read_device_clock(
+    hass: HomeAssistant, device: THZDevice, write_manager
+) -> datetime | None:
+    """Read the device's current date/time from its 5 pClock* registers.
+
+    Returns a naive datetime representing the device's own wall-clock
+    reading (no timezone concept on the device side), or None if any of the
+    five registers is missing from the current register map or unreadable.
+    """
+    write_registers = write_manager.get_all_registers()
+    parts: dict[str, int] = {}
+    for name in _CLOCK_REGISTER_NAMES:
+        entry = write_registers.get(name)
+        if entry is None:
+            return None
+        async with device.lock:
+            value_bytes = await hass.async_add_executor_job(
+                device.read_value,
+                bytes.fromhex(entry["command"]),
+                "get",
+                WRITE_REGISTER_OFFSET,
+                WRITE_REGISTER_LENGTH,
+            )
+        if not value_bytes:
+            return None
+        try:
+            parts[name] = int(
+                THZValueCodec.decode_number(value_bytes, 1.0, entry["decode_type"])
+            )
+        except (ValueError, IndexError):
+            return None
+    try:
+        return datetime(
+            2000 + parts["pClockYear"],
+            parts["pClockMonth"],
+            parts["pClockDay"],
+            parts["pClockHour"],
+            parts["pClockMinutes"],
+        )
+    except (KeyError, ValueError):
+        return None
+
+
+async def _async_write_device_clock(
+    hass: HomeAssistant, device: THZDevice, write_manager, when: datetime
+) -> None:
+    """Write ``when`` (a local wall-clock time) onto the 5 pClock* registers.
+
+    Bypasses each register's declared min/max (pClockYear's in particular is
+    a stale "12".."20" bound) since the value being written is always a
+    freshly computed, valid current date/time component, never user input.
+    """
+    write_registers = write_manager.get_all_registers()
+    values = {
+        "pClockYear": when.year % 100,
+        "pClockMonth": when.month,
+        "pClockDay": when.day,
+        "pClockHour": when.hour,
+        "pClockMinutes": when.minute,
+    }
+    for name, value in values.items():
+        entry = write_registers.get(name)
+        if entry is None:
+            continue
+        value_bytes = THZValueCodec.encode_number(value, 1.0, entry["decode_type"])
+        async with device.lock:
+            await hass.async_add_executor_job(
+                device.write_value, bytes.fromhex(entry["command"]), value_bytes
+            )
+
+
+async def _async_check_and_maybe_sync_clock(
+    hass: HomeAssistant, config_entry: ConfigEntry, device: THZDevice, write_manager
+) -> None:
+    """Periodic check: log clock drift, and auto-correct it if opted in.
+
+    Runs on a fixed timer (see async_setup_entry) independently of the
+    per-entity polling of the individual pClock* registers, so all five
+    components are read together as one consistent snapshot rather than
+    at whatever moments their individual polls happen to land.
+    """
+    device_dt = await _async_read_device_clock(hass, device, write_manager)
+    if device_dt is None:
+        return
+    local_now = dt_util.now().replace(tzinfo=None, second=0, microsecond=0)
+    drift = (device_dt - local_now).total_seconds()
+    if abs(drift) <= _CLOCK_DRIFT_WARN_SECONDS:
+        return
+    _LOGGER.warning(
+        "THZ device clock drifted %.0f minute(s) from local time "
+        "(device=%s, local=%s)",
+        drift / 60, device_dt, local_now,
+    )
+    if config_entry.data.get("auto_sync_clock", False):
+        await _async_write_device_clock(hass, device, write_manager, local_now)
+        _LOGGER.info("THZ device clock auto-corrected to %s", local_now)
+        return
+
+    # auto_sync_clock is off, so this drift can't be corrected automatically.
+    # Surface it to the user — but at most once per calendar day, since this
+    # check runs every 15 minutes and a persistently-drifted clock would
+    # otherwise spam a fresh notification ~96 times a day.
+    entry_data = hass.data.get(DOMAIN, {}).get(config_entry.entry_id)
+    today = dt_util.now().date()
+    if entry_data is not None and entry_data.get("_clock_notify_date") == today:
+        return
+    if entry_data is not None:
+        entry_data["_clock_notify_date"] = today
+    await hass.services.async_call(
+        "persistent_notification",
+        "create",
+        {
+            "title": "THZ Device Clock Drifted",
+            "message": (
+                f"The heat pump's clock is off by about {abs(drift) / 60:.0f} "
+                f"minute(s) (device reads {device_dt.strftime('%Y-%m-%d %H:%M')}, "
+                f"local time is {local_now.strftime('%Y-%m-%d %H:%M')}).\n\n"
+                "Auto-sync clock is turned off, so this wasn't corrected "
+                "automatically. Enable it under the integration's "
+                "Reconfigure screen to fix this going forward."
+            ),
+            "notification_id": f"thz_clock_drift_{config_entry.entry_id}",
+        },
+        blocking=True,
+    )
 
 
 async def _async_setup_services(hass: HomeAssistant) -> None:
@@ -612,6 +851,408 @@ async def _async_setup_services(hass: HomeAssistant) -> None:
         _LOGGER.info("Diverter valve command sent: position=%s confirmed_off=%s", position, confirmed)
         return {"success": True, "position": position, "confirmed_off": confirmed}
 
+    async def _async_handle_backup_parameters(call: ServiceCall) -> ServiceResponse:
+        """Handle the backup_parameters service call.
+
+        Reads the live value of every writable parameter — number, switch,
+        select, time and schedule registers — and writes a timestamped JSON
+        snapshot under config/thz_backups/. That folder lives inside the HA
+        config directory, so it rides along with Home Assistant's own
+        Backup feature automatically: no separate export/import step needed
+        to keep the snapshot safe. restore_parameters is what actually pushes
+        a saved snapshot's values back onto the physical heat pump — restoring
+        an HA backup only restores files, it can't rewrite device registers.
+        """
+        requested_entry_id: str | None = call.data.get("entry_id")
+        label: str | None = call.data.get("label")
+
+        entry_data, error = _resolve_entry_data(hass, requested_entry_id)
+        if error:
+            _LOGGER.error("backup_parameters: %s", error["error"])
+            return error
+
+        write_manager = entry_data["write_manager"]
+        device: THZDevice = entry_data["device"]
+        device_id = entry_data["device_id"]
+        entry_id_used = requested_entry_id or next(
+            (eid for eid, ed in hass.data.get(DOMAIN, {}).items() if ed is entry_data),
+            None,
+        )
+
+        write_registers = write_manager.get_all_registers()
+        parameters: dict[str, dict] = {}
+        read_errors: list[str] = []
+
+        for name, entry in write_registers.items():
+            reg_type = entry.get("type")
+            if reg_type not in _RESTORABLE_REGISTER_TYPES:
+                continue
+            try:
+                command = entry["command"]
+                if reg_type == "schedule":
+                    async with device.lock:
+                        value_bytes = await hass.async_add_executor_job(
+                            device.read_value, bytes.fromhex(command), "get", 4, 4
+                        )
+                    if not value_bytes or len(value_bytes) < 2:
+                        raise ValueError("no data received")
+                    start = quarters_to_time(value_bytes[0])
+                    end = quarters_to_time(value_bytes[1])
+                    value: Any = {
+                        "start": start.strftime("%H:%M") if start else None,
+                        "end": end.strftime("%H:%M") if end else None,
+                    }
+                else:
+                    async with device.lock:
+                        value_bytes = await hass.async_add_executor_job(
+                            device.read_value,
+                            bytes.fromhex(command),
+                            "get",
+                            WRITE_REGISTER_OFFSET,
+                            WRITE_REGISTER_LENGTH,
+                        )
+                    if not value_bytes:
+                        raise ValueError("no data received")
+
+                    if reg_type == "number":
+                        step_raw = entry.get("step", 1)
+                        step = float(step_raw) if step_raw != "" else 1.0
+                        value = THZValueCodec.decode_number(
+                            value_bytes, step, entry["decode_type"]
+                        )
+                    elif reg_type == "switch":
+                        value = THZValueCodec.decode_switch(value_bytes)
+                    elif reg_type == "select":
+                        value = THZValueCodec.decode_select(
+                            value_bytes, entry.get("decode_type")
+                        )
+                    else:  # "time"
+                        t = quarters_to_time(value_bytes[0])
+                        value = t.strftime("%H:%M") if t else None
+
+                parameters[name] = {"type": reg_type, "command": command, "value": value}
+            except Exception as err:  # noqa: BLE001
+                read_errors.append(f"{name}: {err}")
+                _LOGGER.warning("backup_parameters: failed to read %s: %s", name, err)
+
+        # Sanity-check the device's real-time clock against local time.
+        # Backup is otherwise read-only, but a grossly wrong clock (over an
+        # hour off — e.g. after a power loss or reset) throws off every
+        # schedule the heat pump runs, so it's corrected here as a
+        # deliberate exception. Smaller drift is left alone; that's what the
+        # periodic auto_sync_clock check (1-minute threshold) is for.
+        #
+        # Read via _async_read_device_clock rather than pulling from
+        # `parameters` above: the five pClock* registers are type "pclean"
+        # (no platform claims that type as an entity), so they're never
+        # added to `parameters` by the loop's _RESTORABLE_REGISTER_TYPES
+        # filter — reading them back out of it here would always miss.
+        clock_drift_seconds: float | None = None
+        clock_corrected = False
+        device_dt = await _async_read_device_clock(hass, device, write_manager)
+        if device_dt is not None:
+            local_now = dt_util.now().replace(tzinfo=None, second=0, microsecond=0)
+            clock_drift_seconds = (device_dt - local_now).total_seconds()
+            if abs(clock_drift_seconds) > _CLOCK_DRIFT_BACKUP_SECONDS:
+                await _async_write_device_clock(hass, device, write_manager, local_now)
+                clock_corrected = True
+                _LOGGER.warning(
+                    "backup_parameters: device clock was off by %.0f minute(s) "
+                    "(device=%s, local=%s); corrected to local time.",
+                    clock_drift_seconds / 60, device_dt, local_now,
+                )
+        else:
+            _LOGGER.debug(
+                "backup_parameters: could not read device clock to evaluate drift"
+            )
+
+        created = dt_util.utcnow().isoformat()
+        backup_doc = {
+            "created": created,
+            "device_id": device_id,
+            "entry_id": entry_id_used,
+            "firmware_version": getattr(device, "firmware_version", None),
+            "parameter_count": len(parameters),
+            "parameters": parameters,
+        }
+
+        timestamp = dt_util.utcnow().strftime("%Y%m%d-%H%M%S")
+        filename = f"thz_backup_{timestamp}{_sanitize_label(label)}.json"
+
+        def _write_backup_file() -> str:
+            backups_dir = _backups_dir(hass)
+            os.makedirs(backups_dir, exist_ok=True)
+            path = os.path.join(backups_dir, filename)
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(backup_doc, f, indent=2, sort_keys=True)
+            return path
+
+        try:
+            path = await hass.async_add_executor_job(_write_backup_file)
+        except OSError as err:
+            error_msg = f"Failed to write backup file: {err}"
+            _LOGGER.error(error_msg)
+            return {"success": False, "error": error_msg}
+
+        _LOGGER.info(
+            "THZ backup_parameters: saved %d parameters to %s (%d read errors)",
+            len(parameters), path, len(read_errors),
+        )
+        return {
+            "success": True,
+            "file": filename,
+            "path": path,
+            "parameter_count": len(parameters),
+            "read_errors": read_errors[:20],
+            "created": created,
+            "clock_drift_seconds": clock_drift_seconds,
+            "clock_corrected": clock_corrected,
+        }
+
+    async def _async_handle_restore_parameters(call: ServiceCall) -> ServiceResponse:
+        """Handle the restore_parameters service call.
+
+        Reads a JSON snapshot previously written by backup_parameters and
+        pushes each value back onto the device. Every parameter's command
+        and type are re-resolved from the *current* live register map by
+        name — never trusted from the backup file itself — so a restore
+        stays correct even if the integration's register map has changed
+        since the backup was taken. Parameters no longer present are
+        skipped and reported rather than failing the whole restore.
+        """
+        requested_entry_id: str | None = call.data.get("entry_id")
+        requested_filename: str | None = call.data.get("filename")
+        dry_run: bool = bool(call.data.get("dry_run", False))
+        only: list[str] | None = call.data.get("only")
+        only_set = set(only) if only else None
+
+        entry_data, error = _resolve_entry_data(hass, requested_entry_id)
+        if error:
+            _LOGGER.error("restore_parameters: %s", error["error"])
+            return error
+
+        write_manager = entry_data["write_manager"]
+        device: THZDevice = entry_data["device"]
+
+        def _resolve_backup_path() -> str | None:
+            backups_dir = _backups_dir(hass)
+            if requested_filename:
+                candidate = os.path.join(
+                    backups_dir, os.path.basename(requested_filename)
+                )
+                return candidate if os.path.isfile(candidate) else None
+            if not os.path.isdir(backups_dir):
+                return None
+            files = [
+                f for f in os.listdir(backups_dir)
+                if f.startswith("thz_backup_") and f.endswith(".json")
+            ]
+            if not files:
+                return None
+            files.sort(reverse=True)  # timestamp-prefixed names sort chronologically
+            return os.path.join(backups_dir, files[0])
+
+        path = await hass.async_add_executor_job(_resolve_backup_path)
+        if not path:
+            error_msg = (
+                f"Backup file '{requested_filename}' not found"
+                if requested_filename
+                else "No backup files found in thz_backups/"
+            )
+            _LOGGER.error("restore_parameters: %s", error_msg)
+            return {"success": False, "error": error_msg}
+
+        def _read_backup() -> dict:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+
+        try:
+            backup_doc = await hass.async_add_executor_job(_read_backup)
+        except (OSError, ValueError) as err:
+            error_msg = f"Failed to read backup file '{path}': {err}"
+            _LOGGER.error(error_msg)
+            return {"success": False, "error": error_msg}
+
+        saved_parameters: dict[str, dict] = backup_doc.get("parameters", {})
+        write_registers = write_manager.get_all_registers()
+
+        restored = 0
+        skipped_missing: list[str] = []
+        failed: list[str] = []
+
+        for name, saved in saved_parameters.items():
+            if name in _CLOCK_REGISTER_NAMES:
+                # The device's real-time clock is never restored from a
+                # backed-up value — that would set it back to whenever the
+                # backup was taken. It's synced to the current local time
+                # separately below instead.
+                continue
+            if only_set is not None and name not in only_set:
+                continue
+            entry = write_registers.get(name)
+            if entry is None or entry.get("type") not in _RESTORABLE_REGISTER_TYPES:
+                skipped_missing.append(name)
+                continue
+
+            reg_type = entry["type"]
+            command = entry["command"]
+            value = saved.get("value")
+
+            try:
+                if reg_type == "number":
+                    step_raw = entry.get("step", 1)
+                    step = float(step_raw) if step_raw != "" else 1.0
+                    num_value = float(value)
+                    min_raw, max_raw = entry.get("min"), entry.get("max")
+                    if min_raw not in (None, ""):
+                        try:
+                            num_value = max(num_value, float(min_raw))
+                        except (TypeError, ValueError):
+                            pass
+                    if max_raw not in (None, ""):
+                        try:
+                            num_value = min(num_value, float(max_raw))
+                        except (TypeError, ValueError):
+                            pass
+                    value_bytes = THZValueCodec.encode_number(
+                        num_value, step, entry["decode_type"]
+                    )
+                elif reg_type == "switch":
+                    value_bytes = THZValueCodec.encode_switch(bool(value))
+                elif reg_type == "select":
+                    value_bytes = THZValueCodec.encode_select(
+                        value, entry.get("decode_type")
+                    )
+                elif reg_type == "time":
+                    t_value = _parse_hhmm(value)
+                    num = time_to_quarters(t_value)
+                    value_bytes = bytes([num, 0])
+                elif reg_type == "schedule":
+                    start_value = _parse_hhmm(value.get("start")) if value else None
+                    end_value = _parse_hhmm(value.get("end")) if value else None
+                    async with device.lock:
+                        current_bytes = await hass.async_add_executor_job(
+                            device.read_value, bytes.fromhex(command), "get", 4, 4
+                        )
+                    schedule_bytes = bytearray(current_bytes)
+                    schedule_bytes[0] = time_to_quarters(start_value)
+                    schedule_bytes[1] = time_to_quarters(end_value, is_end_time=True)
+                    value_bytes = bytes(schedule_bytes)
+                else:
+                    skipped_missing.append(name)
+                    continue
+            except (ValueError, TypeError, KeyError, IndexError) as err:
+                failed.append(f"{name}: {err}")
+                continue
+
+            if dry_run:
+                restored += 1
+                continue
+
+            try:
+                async with device.lock:
+                    await hass.async_add_executor_job(
+                        device.write_value, bytes.fromhex(command), value_bytes
+                    )
+                restored += 1
+            except (OSError, RuntimeError, ConnectionError) as err:
+                failed.append(f"{name}: {err}")
+
+        # The device clock is always synced to the current local time as
+        # part of a restore, never taken from the backup file — see the
+        # skip above. dry_run skips this write too, and just reports what
+        # the target time would have been.
+        local_now = dt_util.now().replace(tzinfo=None, second=0, microsecond=0)
+        clock_synced = False
+        if not dry_run:
+            try:
+                await _async_write_device_clock(hass, device, write_manager, local_now)
+                clock_synced = True
+            except (OSError, RuntimeError, ConnectionError) as err:
+                failed.append(f"<device clock>: {err}")
+
+        _LOGGER.info(
+            "THZ restore_parameters: %s%d restored, %d skipped (missing), "
+            "%d failed, clock_synced=%s, from %s",
+            "[DRY RUN] " if dry_run else "",
+            restored, len(skipped_missing), len(failed), clock_synced, path,
+        )
+
+        notification_message = (
+            f"File: {os.path.basename(path)}\n"
+            f"Backup created: {backup_doc.get('created')}\n"
+            f"Restored: {restored} / {len(saved_parameters)}\n"
+            f"Skipped (missing): {len(skipped_missing)}\n"
+            f"Failed: {len(failed)}\n"
+            + (
+                f"Clock synced to: {local_now.isoformat(timespec='minutes')}"
+                if clock_synced
+                else f"Clock: would be synced to {local_now.isoformat(timespec='minutes')} (dry run)"
+                if dry_run
+                else "Clock: not synced (write failed, see failed list)"
+            )
+        )
+        await hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {
+                "title": f"THZ Parameter Restore {'(dry run) ' if dry_run else ''}Complete",
+                "message": notification_message,
+                "notification_id": "thz_restore_parameters",
+            },
+            blocking=True,
+        )
+
+        return {
+            "success": True,
+            "dry_run": dry_run,
+            "file": os.path.basename(path),
+            "backup_created": backup_doc.get("created"),
+            "total_in_backup": len(saved_parameters),
+            "restored": restored,
+            "skipped_missing": skipped_missing[:20],
+            "skipped_missing_count": len(skipped_missing),
+            "failed": failed[:20],
+            "failed_count": len(failed),
+            "clock_synced": clock_synced,
+            "clock_target": local_now.isoformat(timespec="minutes"),
+        }
+
+    async def _async_handle_list_parameter_backups(call: ServiceCall) -> ServiceResponse:
+        """Handle the list_parameter_backups service call.
+
+        Lists the parameter backup files under config/thz_backups/, newest
+        first, so a filename can be picked and passed to restore_parameters.
+        """
+
+        def _list() -> list[dict]:
+            backups_dir = _backups_dir(hass)
+            if not os.path.isdir(backups_dir):
+                return []
+            results = []
+            for fname in sorted(os.listdir(backups_dir), reverse=True):
+                if not (fname.startswith("thz_backup_") and fname.endswith(".json")):
+                    continue
+                fpath = os.path.join(backups_dir, fname)
+                info: dict[str, Any] = {
+                    "filename": fname,
+                    "size_bytes": os.path.getsize(fpath),
+                }
+                try:
+                    with open(fpath, "r", encoding="utf-8") as f:
+                        doc = json.load(f)
+                    info["created"] = doc.get("created")
+                    info["parameter_count"] = doc.get("parameter_count")
+                    info["device_id"] = doc.get("device_id")
+                    info["firmware_version"] = doc.get("firmware_version")
+                except (OSError, ValueError):
+                    pass
+                results.append(info)
+            return results
+
+        backups = await hass.async_add_executor_job(_list)
+        return {"success": True, "count": len(backups), "backups": backups}
+
     # Register services
     hass.services.async_register(
         DOMAIN,
@@ -641,6 +1282,35 @@ async def _async_setup_services(hass: HomeAssistant) -> None:
             vol.Required("position"): vol.In(["heating", "dhw", "off"]),
             vol.Optional("entry_id"): cv.string,
         }),
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "backup_parameters",
+        _async_handle_backup_parameters,
+        schema=vol.Schema({
+            vol.Optional("entry_id"): cv.string,
+            vol.Optional("label"): cv.string,
+        }),
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "restore_parameters",
+        _async_handle_restore_parameters,
+        schema=vol.Schema({
+            vol.Optional("entry_id"): cv.string,
+            vol.Optional("filename"): cv.string,
+            vol.Optional("dry_run", default=False): cv.boolean,
+            vol.Optional("only"): [cv.string],
+        }),
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "list_parameter_backups",
+        _async_handle_list_parameter_backups,
+        schema=vol.Schema({}),
         supports_response=SupportsResponse.OPTIONAL,
     )
     _LOGGER.info("THZ services registered")
@@ -792,6 +1462,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Clean up device connection
         entry_data = hass.data[DOMAIN].get(entry.entry_id)
         if entry_data:
+            unsub_clock_check = entry_data.get("unsub_clock_check")
+            if unsub_clock_check:
+                unsub_clock_check()
             device = entry_data.get("device")
             if device:
                 await hass.async_add_executor_job(device.close)
@@ -807,6 +1480,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.services.async_remove(DOMAIN, "read_raw_register")
             hass.services.async_remove(DOMAIN, "refresh_block")
             hass.services.async_remove(DOMAIN, "set_diverter_valve")
+            hass.services.async_remove(DOMAIN, "backup_parameters")
+            hass.services.async_remove(DOMAIN, "restore_parameters")
+            hass.services.async_remove(DOMAIN, "list_parameter_backups")
 
     return unload_ok
 

--- a/custom_components/thz/config_flow.py
+++ b/custom_components/thz/config_flow.py
@@ -260,6 +260,18 @@ class THZConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             default=defaults.get("write_interval", DEFAULT_WRITE_INTERVAL),
         )] = vol.All(int, vol.Range(min=5, max=86400))
 
+        # Auto-sync the device's real-time clock. Off by default: the clock
+        # is always checked every 15 minutes and drift beyond a minute is
+        # logged either way, but this only enables actually WRITING a
+        # correction back to the device on that periodic check. (Independent
+        # of the backup_parameters / restore_parameters services, which
+        # always correct/sync the clock outright — this only governs the
+        # ongoing background check.)
+        schema_dict[vol.Optional(
+            "auto_sync_clock",
+            default=defaults.get("auto_sync_clock", False),
+        )] = bool
+
         return vol.Schema(schema_dict)
 
     async def get_ports(

--- a/custom_components/thz/services.yaml
+++ b/custom_components/thz/services.yaml
@@ -72,3 +72,83 @@ read_raw_register:
       example: "FB"
       selector:
         text:
+
+backup_parameters:
+  name: Backup Parameters
+  description: >
+    Save the current value of every writable LWZ/THZ parameter (heating
+    curves, schedules, DHW settings, and other number/switch/select/time
+    registers) to a timestamped JSON file under config/thz_backups/.
+    That folder lives inside the Home Assistant config directory, so it is
+    automatically included in — and brought back by — Home Assistant's own
+    Backup feature, with no separate export step. Use restore_parameters
+    afterwards to actually push a saved snapshot's values back onto the
+    heat pump (for example after a full factory reset).
+  fields:
+    label:
+      name: Label
+      description: >
+        Optional short label appended to the backup's filename, e.g.
+        "before_reset". Letters, numbers, "-" and "_" only.
+      required: false
+      example: "before_reset"
+      selector:
+        text:
+    entry_id:
+      name: Entry ID
+      description: Config entry ID. Only required when multiple THZ devices are configured.
+      required: false
+      selector:
+        text:
+
+restore_parameters:
+  name: Restore Parameters
+  description: >
+    Push the values from a saved parameter backup back onto the heat pump.
+    Each parameter is written using the integration's current register map,
+    so a restore keeps working even if the integration has been updated
+    since the backup was taken — parameters no longer present are skipped
+    and reported rather than failing the whole restore. Set dry_run to
+    preview what would be written without touching the device.
+  fields:
+    filename:
+      name: Backup file
+      description: >
+        Filename of the backup to restore, as returned by
+        list_parameter_backups (e.g. "thz_backup_20260825-120000.json").
+        If omitted, the most recent backup is used.
+      required: false
+      example: "thz_backup_20260825-120000.json"
+      selector:
+        text:
+    dry_run:
+      name: Dry run
+      description: >
+        If enabled, nothing is written to the device — the response reports
+        what would have been restored instead.
+      required: false
+      selector:
+        boolean:
+    only:
+      name: Only these parameters
+      description: >
+        Optional list of parameter names to restore, restricting the
+        operation to a subset of the backup (e.g. just the heating curve
+        parameters). Leave empty to restore everything in the backup.
+      required: false
+      selector:
+        text:
+          multiple: true
+    entry_id:
+      name: Entry ID
+      description: Config entry ID. Only required when multiple THZ devices are configured.
+      required: false
+      selector:
+        text:
+
+list_parameter_backups:
+  name: List Parameter Backups
+  description: >
+    List the parameter backup files saved under config/thz_backups/, newest
+    first, with each one's creation time and parameter count — use this to
+    find the filename to pass to restore_parameters.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,8 @@ class MockButtonEntity(MockEntity):
 
 # Mock Home Assistant modules
 sys.modules['homeassistant'] = MagicMock()
+sys.modules['homeassistant.util'] = MagicMock()
+sys.modules['homeassistant.util.dt'] = MagicMock()
 sys.modules['homeassistant.config_entries'] = MagicMock()
 sys.modules['homeassistant.core'] = MagicMock()
 sys.modules['homeassistant.helpers'] = MagicMock()

--- a/tests/test_backup_restore_services.py
+++ b/tests/test_backup_restore_services.py
@@ -1,0 +1,940 @@
+"""Tests for the parameter backup/restore services and clock-drift helpers.
+
+Covers the new backup_parameters / restore_parameters / list_parameter_backups
+services in custom_components/thz/__init__.py, plus their small supporting
+helpers (_sanitize_label, _parse_hhmm, _resolve_entry_data) and the
+_async_check_and_maybe_sync_clock regression: the clock drift check must read
+the device clock via the dedicated pClock* helper rather than pulling it out
+of the "restorable parameters" dict (which filters out "pclean"-typed
+registers and would silently never see the clock at all).
+"""
+import asyncio
+import json
+from datetime import datetime, time as dt_time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.thz.const import DOMAIN
+
+
+# ---------------------------------------------------------------------------
+# Small pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeLabel:
+    """Tests for _sanitize_label."""
+
+    def test_none_returns_empty(self):
+        from custom_components.thz import _sanitize_label
+
+        assert _sanitize_label(None) == ""
+
+    def test_empty_string_returns_empty(self):
+        from custom_components.thz import _sanitize_label
+
+        assert _sanitize_label("") == ""
+
+    def test_valid_label_passes_through_with_prefix(self):
+        from custom_components.thz import _sanitize_label
+
+        assert _sanitize_label("before_reset") == "_before_reset"
+        assert _sanitize_label("test-123") == "_test-123"
+
+    def test_invalid_characters_replaced_with_underscore(self):
+        from custom_components.thz import _sanitize_label
+
+        # Spaces, slashes, dots etc are not alnum/-/_ so become "_", then
+        # leading/trailing underscores are stripped.
+        assert _sanitize_label("before reset!") == "_before_reset"
+        assert _sanitize_label("../../etc/passwd") == "_etc_passwd"
+
+    def test_only_invalid_characters_returns_empty(self):
+        from custom_components.thz import _sanitize_label
+
+        assert _sanitize_label("!!!") == ""
+        assert _sanitize_label("   ") == ""
+
+    def test_strips_surrounding_whitespace(self):
+        from custom_components.thz import _sanitize_label
+
+        assert _sanitize_label("  my label  ") == "_my_label"
+
+
+class TestParseHHMM:
+    """Tests for _parse_hhmm."""
+
+    def test_none_returns_none(self):
+        from custom_components.thz import _parse_hhmm
+
+        assert _parse_hhmm(None) is None
+
+    def test_empty_string_returns_none(self):
+        from custom_components.thz import _parse_hhmm
+
+        assert _parse_hhmm("") is None
+
+    def test_valid_hhmm(self):
+        from custom_components.thz import _parse_hhmm
+
+        assert _parse_hhmm("06:30") == dt_time(6, 30)
+        assert _parse_hhmm("23:45") == dt_time(23, 45)
+        assert _parse_hhmm("00:00") == dt_time(0, 0)
+
+    def test_invalid_format_raises(self):
+        from custom_components.thz import _parse_hhmm
+
+        with pytest.raises(ValueError):
+            _parse_hhmm("not-a-time")
+
+    def test_missing_colon_raises(self):
+        from custom_components.thz import _parse_hhmm
+
+        with pytest.raises(ValueError):
+            _parse_hhmm("0630")
+
+
+class TestResolveEntryData:
+    """Tests for _resolve_entry_data."""
+
+    def test_single_entry_no_entry_id_needed(self):
+        from custom_components.thz import _resolve_entry_data
+
+        hass = MagicMock()
+        entry_data = {"device": MagicMock()}
+        hass.data = {DOMAIN: {"entry_a": entry_data}}
+
+        resolved, error = _resolve_entry_data(hass, None)
+
+        assert error is None
+        assert resolved is entry_data
+
+    def test_no_entries_returns_error(self):
+        from custom_components.thz import _resolve_entry_data
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}
+
+        resolved, error = _resolve_entry_data(hass, None)
+
+        assert resolved is None
+        assert error["success"] is False
+        assert "not initialised" in error["error"]
+
+    def test_multiple_entries_without_entry_id_errors(self):
+        from custom_components.thz import _resolve_entry_data
+
+        hass = MagicMock()
+        hass.data = {
+            DOMAIN: {
+                "entry_a": {"device": MagicMock()},
+                "entry_b": {"device": MagicMock()},
+            }
+        }
+
+        resolved, error = _resolve_entry_data(hass, None)
+
+        assert resolved is None
+        assert error["success"] is False
+        assert "entry_id" in error["error"] or "Multiple" in error["error"]
+
+    def test_multiple_entries_with_correct_entry_id(self):
+        from custom_components.thz import _resolve_entry_data
+
+        hass = MagicMock()
+        entry_a_data = {"device": MagicMock()}
+        entry_b_data = {"device": MagicMock()}
+        hass.data = {DOMAIN: {"entry_a": entry_a_data, "entry_b": entry_b_data}}
+
+        resolved, error = _resolve_entry_data(hass, "entry_b")
+
+        assert error is None
+        assert resolved is entry_b_data
+
+    def test_unknown_entry_id_errors(self):
+        from custom_components.thz import _resolve_entry_data
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_a": {"device": MagicMock()}}}
+
+        resolved, error = _resolve_entry_data(hass, "nonexistent")
+
+        assert resolved is None
+        assert error["success"] is False
+        assert "nonexistent" in error["error"]
+
+
+# ---------------------------------------------------------------------------
+# Clock drift check regression
+# ---------------------------------------------------------------------------
+
+
+class TestClockDriftCheck:
+    """Regression coverage for _async_check_and_maybe_sync_clock.
+
+    The commit under test claims to fix a bug where the periodic drift check
+    read the device clock from a dict that filters out "pclean"-typed
+    registers (the pClock* registers are exactly that type), so the clock
+    value was always missing and the check silently never fired. These tests
+    prove the check now actually reads the clock (via
+    _async_read_device_clock, the same helper the backup service uses) and
+    can trigger both the warning/notification path and the auto-sync path.
+    """
+
+    def _write_registers(self):
+        """Build a minimal write-register map with the 5 pClock* entries."""
+        return {
+            "pClockYear": {"command": "0A0101", "decode_type": "0clean"},
+            "pClockMonth": {"command": "0A0102", "decode_type": "0clean"},
+            "pClockDay": {"command": "0A0103", "decode_type": "0clean"},
+            "pClockHour": {"command": "0A0104", "decode_type": "0clean"},
+            "pClockMinutes": {"command": "0A0105", "decode_type": "0clean"},
+        }
+
+    def _make_write_manager(self):
+        write_manager = MagicMock()
+        write_manager.get_all_registers = MagicMock(
+            return_value=self._write_registers()
+        )
+        return write_manager
+
+    def _make_device(self):
+        device = MagicMock()
+        device.lock = asyncio.Lock()
+        return device
+
+    @pytest.mark.asyncio
+    async def test_read_device_clock_reads_all_five_registers(self):
+        """_async_read_device_clock must actually read pClock* registers.
+
+        This directly exercises the helper that both the periodic check and
+        backup_parameters rely on, proving it does NOT depend on the
+        _RESTORABLE_REGISTER_TYPES-filtered parameters dict (which would
+        never contain "pclean"-typed registers).
+        """
+        from custom_components.thz import _async_read_device_clock
+
+        hass = MagicMock()
+        write_manager = self._make_write_manager()
+        device = self._make_device()
+
+        # Device clock reads: year=26, month=1, day=15, hour=10, minute=30
+        clock_values = [26, 1, 15, 10, 30]
+        hass.async_add_executor_job = AsyncMock(
+            side_effect=[bytes([v]) for v in clock_values]
+        )
+
+        result = await _async_read_device_clock(hass, device, write_manager)
+
+        assert result == datetime(2026, 1, 15, 10, 30)
+        assert hass.async_add_executor_job.call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_read_device_clock_missing_register_returns_none(self):
+        """If a pClock* register isn't in the current map, reading yields None."""
+        from custom_components.thz import _async_read_device_clock
+
+        hass = MagicMock()
+        write_manager = MagicMock()
+        regs = self._write_registers()
+        del regs["pClockMinutes"]
+        write_manager.get_all_registers = MagicMock(return_value=regs)
+        device = self._make_device()
+        hass.async_add_executor_job = AsyncMock(return_value=bytes([1]))
+
+        result = await _async_read_device_clock(hass, device, write_manager)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_drift_check_fires_notification_when_drifted_and_no_autosync(self):
+        """A large drift with auto_sync_clock off must notify, not silently no-op.
+
+        This is the core regression test: before the fix, the drift check
+        read from the pclean-filtered dict and got nothing back, so it
+        always returned early without ever comparing to local time. Here we
+        prove the device clock IS read (5 executor calls) and a
+        persistent_notification IS created because of the drift.
+        """
+        from custom_components.thz import _async_check_and_maybe_sync_clock
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_1": {}}}
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_1"
+        config_entry.data = {"auto_sync_clock": False}
+
+        write_manager = self._make_write_manager()
+        device = self._make_device()
+
+        # Device reports a time 2 hours ahead of "now" -> drift beyond the
+        # 60s warn threshold.
+        local_now = datetime(2026, 8, 25, 10, 0)
+        device_time_parts = [26, 8, 25, 12, 0]  # 2 hours ahead
+        hass.async_add_executor_job = AsyncMock(
+            side_effect=[bytes([v]) for v in device_time_parts]
+        )
+
+        fake_dt_util = MagicMock()
+        fake_dt_util.now = MagicMock(return_value=local_now)
+        fake_dt_util.utcnow = MagicMock(return_value=local_now)
+
+        with patch("custom_components.thz.dt_util", fake_dt_util):
+            await _async_check_and_maybe_sync_clock(
+                hass, config_entry, device, write_manager
+            )
+
+        # Proves the clock was actually read (not skipped due to the bug).
+        assert hass.async_add_executor_job.call_count == 5
+        # Proves the drift comparison actually ran and fired the
+        # notification path.
+        hass.services.async_call.assert_called_once()
+        call_args = hass.services.async_call.call_args
+        assert call_args[0][0] == "persistent_notification"
+        assert call_args[0][1] == "create"
+        assert "drift" in call_args[0][2]["message"].lower() or "off by" in call_args[0][2]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_drift_check_no_notification_when_within_threshold(self):
+        """Small drift (<=60s) must not trigger a notification."""
+        from custom_components.thz import _async_check_and_maybe_sync_clock
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_1": {}}}
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_1"
+        config_entry.data = {"auto_sync_clock": False}
+
+        write_manager = self._make_write_manager()
+        device = self._make_device()
+
+        local_now = datetime(2026, 8, 25, 10, 0)
+        device_time_parts = [26, 8, 25, 10, 0]  # exact match
+        hass.async_add_executor_job = AsyncMock(
+            side_effect=[bytes([v]) for v in device_time_parts]
+        )
+
+        fake_dt_util = MagicMock()
+        fake_dt_util.now = MagicMock(return_value=local_now)
+
+        with patch("custom_components.thz.dt_util", fake_dt_util):
+            await _async_check_and_maybe_sync_clock(
+                hass, config_entry, device, write_manager
+            )
+
+        assert hass.async_add_executor_job.call_count == 5
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drift_check_auto_corrects_when_opted_in(self):
+        """With auto_sync_clock=True, drift beyond threshold writes the clock back."""
+        from custom_components.thz import _async_check_and_maybe_sync_clock
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_1": {}}}
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_1"
+        config_entry.data = {"auto_sync_clock": True}
+
+        write_manager = self._make_write_manager()
+        device = self._make_device()
+
+        local_now = datetime(2026, 8, 25, 10, 0)
+        # 5 reads for the check, then 5 writes for the correction
+        device_time_parts = [26, 8, 25, 12, 0]
+        hass.async_add_executor_job = AsyncMock(
+            side_effect=[bytes([v]) for v in device_time_parts] + [None] * 5
+        )
+
+        fake_dt_util = MagicMock()
+        fake_dt_util.now = MagicMock(return_value=local_now)
+
+        with patch("custom_components.thz.dt_util", fake_dt_util):
+            await _async_check_and_maybe_sync_clock(
+                hass, config_entry, device, write_manager
+            )
+
+        # 5 reads + 5 writes = 10 executor calls; no notification since
+        # auto-correction handled it.
+        assert hass.async_add_executor_job.call_count == 10
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drift_check_returns_early_when_clock_unreadable(self):
+        """If the clock can't be read at all, the check must not crash or notify."""
+        from custom_components.thz import _async_check_and_maybe_sync_clock
+
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_1": {}}}
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "entry_1"
+        config_entry.data = {"auto_sync_clock": False}
+
+        write_manager = MagicMock()
+        regs = self._write_registers()
+        del regs["pClockYear"]
+        write_manager.get_all_registers = MagicMock(return_value=regs)
+        device = self._make_device()
+        hass.async_add_executor_job = AsyncMock(return_value=bytes([1]))
+
+        await _async_check_and_maybe_sync_clock(
+            hass, config_entry, device, write_manager
+        )
+
+        hass.services.async_call.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# backup_parameters / restore_parameters / list_parameter_backups services
+# ---------------------------------------------------------------------------
+
+
+def _sample_write_registers():
+    """A small but representative register map for the backup/restore tests."""
+    return {
+        "pClockYear": {"command": "0A0101", "type": "pclean", "decode_type": "0clean"},
+        "pClockMonth": {"command": "0A0102", "type": "pclean", "decode_type": "0clean"},
+        "pClockDay": {"command": "0A0103", "type": "pclean", "decode_type": "0clean"},
+        "pClockHour": {"command": "0A0104", "type": "pclean", "decode_type": "0clean"},
+        "pClockMinutes": {"command": "0A0105", "type": "pclean", "decode_type": "0clean"},
+        "HeatingCurve": {
+            "command": "0A0200",
+            "type": "number",
+            "decode_type": "hex2int",
+            "step": 0.1,
+            "min": "0.1",
+            "max": "3.5",
+        },
+        "SomeSwitch": {
+            "command": "0A0300",
+            "type": "switch",
+            "decode_type": "hex2int",
+        },
+    }
+
+
+class TestBackupParametersService:
+    """Tests for the backup_parameters service handler."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}
+        hass.services = MagicMock()
+        hass.services.has_service = MagicMock(return_value=False)
+        hass.services.async_register = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.config = MagicMock()
+        hass.config.path = MagicMock(return_value="/config/thz_backups")
+        return hass
+
+    def _entry_data(self):
+        device = MagicMock()
+        device.lock = asyncio.Lock()
+        device.firmware_version = "1.0"
+        write_manager = MagicMock()
+        write_manager.get_all_registers = MagicMock(
+            return_value=_sample_write_registers()
+        )
+        return {
+            "device": device,
+            "device_id": "thz-1234",
+            "write_manager": write_manager,
+        }
+
+    async def _get_handler(self, hass, name="backup_parameters"):
+        from custom_components.thz import _async_setup_services
+
+        await _async_setup_services(hass)
+        for call in hass.services.async_register.call_args_list:
+            if call[0][1] == name:
+                return call[0][2]
+        raise AssertionError(f"service {name} not registered")
+
+    @pytest.mark.asyncio
+    async def test_backup_writes_json_with_expected_shape(self, mock_hass):
+        entry_data = self._entry_data()
+        mock_hass.data[DOMAIN]["entry_1"] = entry_data
+        device = entry_data["device"]
+
+        # Reads happen in this order per register in write_registers dict:
+        # HeatingCurve (number, 2 bytes), SomeSwitch (switch, 2 bytes), then
+        # the 5 clock registers for the drift sanity-check at the end.
+        read_values = {
+            "0A0200": (2, 0),  # HeatingCurve raw bytes -> handled by side_effect list
+            "0A0300": (0, 1),
+        }
+
+        async def fake_read_value(command, mode, offset, length):
+            # command is bytes; map back to hex to decide the payload
+            hexcmd = command.hex().upper()
+            if hexcmd == "0A0200":
+                return bytes([0, 20])  # hex2int, step 0.1 -> 2.0
+            if hexcmd == "0A0300":
+                return bytes([0, 1])  # switch on
+            if hexcmd in ("0A0101",):
+                return bytes([26])
+            if hexcmd == "0A0102":
+                return bytes([8])
+            if hexcmd == "0A0103":
+                return bytes([25])
+            if hexcmd == "0A0104":
+                return bytes([10])
+            if hexcmd == "0A0105":
+                return bytes([0])
+            raise AssertionError(f"unexpected command {hexcmd}")
+
+        async def fake_executor_job(func, *args, **kwargs):
+            if func is device.read_value:
+                return await fake_read_value(*args)
+            # file write executor job
+            return func(*args, **kwargs)
+
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=fake_executor_job)
+
+        fake_dt_util = MagicMock()
+        fake_dt_util.now = MagicMock(
+            return_value=datetime(2026, 8, 25, 10, 0)
+        )
+        fake_dt_util.utcnow = MagicMock(
+            return_value=datetime(2026, 8, 25, 10, 0)
+        )
+
+        written = {}
+
+        def fake_open(path, mode="r", encoding=None):
+            from io import StringIO
+
+            buf = StringIO()
+            orig_close = buf.close
+
+            def close():
+                written["path"] = path
+                written["content"] = buf.getvalue()
+
+            buf.close = close
+            return buf
+
+        with patch("custom_components.thz.dt_util", fake_dt_util), \
+             patch("os.makedirs"), \
+             patch("builtins.open", side_effect=fake_open):
+            handler = await self._get_handler(mock_hass, "backup_parameters")
+            call = MagicMock()
+            call.data = {"label": "my label!"}
+            result = await handler(call)
+
+        assert result["success"] is True
+        assert result["parameter_count"] == 2  # HeatingCurve + SomeSwitch
+        assert result["file"].startswith("thz_backup_20260825-100000")
+        assert result["file"].endswith("_my_label.json")
+
+        doc = json.loads(written["content"])
+        assert doc["device_id"] == "thz-1234"
+        assert doc["parameter_count"] == 2
+        assert "HeatingCurve" in doc["parameters"]
+        assert doc["parameters"]["HeatingCurve"]["value"] == pytest.approx(2.0)
+        assert doc["parameters"]["SomeSwitch"]["value"] is True
+        # pClock* registers must never appear as ordinary parameters
+        assert "pClockYear" not in doc["parameters"]
+
+        # Verify device reads actually happened for the writable entries
+        # (2 param reads + 5 clock reads for the drift sanity check + 1
+        # executor job for the file write itself).
+        assert mock_hass.async_add_executor_job.await_count == 8
+
+    @pytest.mark.asyncio
+    async def test_backup_no_device_returns_error(self, mock_hass):
+        mock_hass.async_add_executor_job = AsyncMock()
+        handler = await self._get_handler(mock_hass, "backup_parameters")
+        call = MagicMock()
+        call.data = {}
+
+        result = await handler(call)
+
+        assert result["success"] is False
+        assert "error" in result
+
+
+class TestListParameterBackupsService:
+    """Tests for the list_parameter_backups service handler."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}
+        hass.services = MagicMock()
+        hass.services.has_service = MagicMock(return_value=False)
+        hass.services.async_register = MagicMock()
+        hass.config = MagicMock()
+        hass.config.path = MagicMock(return_value="/config/thz_backups")
+        return hass
+
+    async def _get_handler(self, hass):
+        from custom_components.thz import _async_setup_services
+
+        await _async_setup_services(hass)
+        for call in hass.services.async_register.call_args_list:
+            if call[0][1] == "list_parameter_backups":
+                return call[0][2]
+        raise AssertionError("list_parameter_backups not registered")
+
+    @pytest.mark.asyncio
+    async def test_lists_newest_first_with_metadata(self, mock_hass):
+        files = [
+            "thz_backup_20260101-000000.json",
+            "thz_backup_20260825-100000.json",
+            "thz_backup_20260601-120000_label.json",
+            "not_a_backup.txt",
+        ]
+        docs = {
+            "thz_backup_20260101-000000.json": {
+                "created": "2026-01-01T00:00:00+00:00",
+                "parameter_count": 3,
+                "device_id": "thz-1234",
+                "firmware_version": "1.0",
+            },
+            "thz_backup_20260825-100000.json": {
+                "created": "2026-08-25T10:00:00+00:00",
+                "parameter_count": 5,
+                "device_id": "thz-1234",
+                "firmware_version": "1.1",
+            },
+            "thz_backup_20260601-120000_label.json": {
+                "created": "2026-06-01T12:00:00+00:00",
+                "parameter_count": 4,
+                "device_id": "thz-1234",
+                "firmware_version": "1.0",
+            },
+        }
+
+        def fake_open(path, mode="r", encoding=None):
+            from io import StringIO
+
+            fname = path.split("/")[-1]
+            return StringIO(json.dumps(docs[fname]))
+
+        async def fake_executor_job(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=fake_executor_job)
+
+        with patch("os.path.isdir", return_value=True), \
+             patch("os.listdir", return_value=files), \
+             patch("os.path.getsize", return_value=123), \
+             patch("builtins.open", side_effect=fake_open):
+            handler = await self._get_handler(mock_hass)
+            call = MagicMock()
+            call.data = {}
+            result = await handler(call)
+
+        assert result["success"] is True
+        assert result["count"] == 3
+        names = [b["filename"] for b in result["backups"]]
+        # Newest first (lexicographic == chronological for these filenames)
+        assert names == [
+            "thz_backup_20260825-100000.json",
+            "thz_backup_20260601-120000_label.json",
+            "thz_backup_20260101-000000.json",
+        ]
+        assert result["backups"][0]["parameter_count"] == 5
+        assert result["backups"][0]["device_id"] == "thz-1234"
+
+    @pytest.mark.asyncio
+    async def test_no_backups_dir_returns_empty(self, mock_hass):
+        async def fake_executor_job(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=fake_executor_job)
+
+        with patch("os.path.isdir", return_value=False):
+            handler = await self._get_handler(mock_hass)
+            call = MagicMock()
+            call.data = {}
+            result = await handler(call)
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["backups"] == []
+
+
+class TestRestoreParametersService:
+    """Tests for the restore_parameters service handler."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}
+        hass.services = MagicMock()
+        hass.services.has_service = MagicMock(return_value=False)
+        hass.services.async_register = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.config = MagicMock()
+        hass.config.path = MagicMock(return_value="/config/thz_backups")
+        return hass
+
+    def _entry_data(self):
+        device = MagicMock()
+        device.lock = asyncio.Lock()
+        write_manager = MagicMock()
+        write_manager.get_all_registers = MagicMock(
+            return_value=_sample_write_registers()
+        )
+        return {
+            "device": device,
+            "device_id": "thz-1234",
+            "write_manager": write_manager,
+        }
+
+    async def _get_handler(self, hass):
+        from custom_components.thz import _async_setup_services
+
+        await _async_setup_services(hass)
+        for call in hass.services.async_register.call_args_list:
+            if call[0][1] == "restore_parameters":
+                return call[0][2]
+        raise AssertionError("restore_parameters not registered")
+
+    def _backup_doc(self, **overrides):
+        doc = {
+            "created": "2026-08-20T00:00:00+00:00",
+            "device_id": "thz-1234",
+            "parameters": {
+                "HeatingCurve": {
+                    "type": "number",
+                    "command": "0A0200",
+                    "value": 1.5,
+                },
+                "SomeSwitch": {
+                    "type": "switch",
+                    "command": "0A0300",
+                    "value": True,
+                },
+                "GhostParam": {
+                    "type": "number",
+                    "command": "0AFFFF",
+                    "value": 42,
+                },
+                "pClockYear": {"type": "pclean", "command": "0A0101", "value": 26},
+            },
+        }
+        doc.update(overrides)
+        return doc
+
+    def _patch_common(self, mock_hass, backup_doc, device):
+        """Return the set of context managers common to restore tests."""
+        fake_dt_util = MagicMock()
+        fake_dt_util.now = MagicMock(return_value=datetime(2026, 8, 25, 10, 0))
+
+        async def fake_executor_job(func, *args, **kwargs):
+            if func is device.write_value:
+                return None
+            if func is device.read_value:
+                return bytes([0, 0])
+            return func(*args, **kwargs)
+
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=fake_executor_job)
+
+        def fake_open(path, mode="r", encoding=None):
+            from io import StringIO
+
+            return StringIO(json.dumps(backup_doc))
+
+        return fake_dt_util, fake_open
+
+    @pytest.mark.asyncio
+    async def test_dry_run_writes_nothing_to_device(self, mock_hass):
+        entry_data = self._entry_data()
+        mock_hass.data[DOMAIN]["entry_1"] = entry_data
+        device = entry_data["device"]
+        backup_doc = self._backup_doc()
+        fake_dt_util, fake_open = self._patch_common(mock_hass, backup_doc, device)
+
+        with patch("custom_components.thz.dt_util", fake_dt_util), \
+             patch("os.path.isfile", return_value=True), \
+             patch("builtins.open", side_effect=fake_open):
+            handler = await self._get_handler(mock_hass)
+            call = MagicMock()
+            call.data = {"filename": "thz_backup_x.json", "dry_run": True}
+            result = await handler(call)
+
+        assert result["success"] is True
+        assert result["dry_run"] is True
+        assert result["restored"] == 2  # HeatingCurve + SomeSwitch (Ghost skipped)
+        assert result["clock_synced"] is False
+        # No device writes should have happened in dry-run mode.
+        write_calls = [
+            c for c in mock_hass.async_add_executor_job.await_args_list
+            if c.args and c.args[0] is device.write_value
+        ]
+        assert write_calls == []
+
+    @pytest.mark.asyncio
+    async def test_only_restricts_to_subset(self, mock_hass):
+        entry_data = self._entry_data()
+        mock_hass.data[DOMAIN]["entry_1"] = entry_data
+        device = entry_data["device"]
+        backup_doc = self._backup_doc()
+        fake_dt_util, fake_open = self._patch_common(mock_hass, backup_doc, device)
+
+        with patch("custom_components.thz.dt_util", fake_dt_util), \
+             patch("os.path.isfile", return_value=True), \
+             patch("builtins.open", side_effect=fake_open):
+            handler = await self._get_handler(mock_hass)
+            call = MagicMock()
+            call.data = {
+                "filename": "thz_backup_x.json",
+                "only": ["HeatingCurve"],
+                "dry_run": True,
+            }
+            result = await handler(call)
+
+        assert result["success"] is True
+        assert result["restored"] == 1
+        assert result["skipped_missing"] == []
+
+    @pytest.mark.asyncio
+    async def test_ghost_parameter_skipped_not_fatal(self, mock_hass):
+        """A parameter in the backup but absent from the current map is skipped."""
+        entry_data = self._entry_data()
+        mock_hass.data[DOMAIN]["entry_1"] = entry_data
+        device = entry_data["device"]
+        backup_doc = self._backup_doc()
+        fake_dt_util, fake_open = self._patch_common(mock_hass, backup_doc, device)
+
+        with patch("custom_components.thz.dt_util", fake_dt_util), \
+             patch("os.path.isfile", return_value=True), \
+             patch("builtins.open", side_effect=fake_open):
+            handler = await self._get_handler(mock_hass)
+            call = MagicMock()
+            call.data = {"filename": "thz_backup_x.json", "dry_run": True}
+            result = await handler(call)
+
+        assert result["success"] is True
+        assert "GhostParam" in result["skipped_missing"]
+        assert result["skipped_missing_count"] == 1
+        # The overall restore still succeeds despite the missing parameter.
+        assert result["failed_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_reresolves_command_from_current_map_not_backup(self, mock_hass):
+        """The backup's stored command must NOT be trusted; current map wins.
+
+        This is the specific correctness property called out by the commit
+        message: if the register map changed since the backup was taken
+        (e.g. the command byte for a parameter was corrected upstream), a
+        restore must write to the CURRENT command, never the stale one
+        embedded in the backup file.
+        """
+        entry_data = self._entry_data()
+        mock_hass.data[DOMAIN]["entry_1"] = entry_data
+        device = entry_data["device"]
+
+        # Backup claims HeatingCurve's command is 0AFACE (stale/wrong);
+        # the CURRENT register map (from _sample_write_registers) says
+        # 0A0200 is the real command.
+        backup_doc = self._backup_doc()
+        backup_doc["parameters"]["HeatingCurve"]["command"] = "0AFACE"
+
+        fake_dt_util, fake_open = self._patch_common(mock_hass, backup_doc, device)
+
+        written_commands = []
+
+        async def fake_executor_job(func, *args, **kwargs):
+            if func is device.write_value:
+                written_commands.append(args[0])
+                return None
+            if func is device.read_value:
+                return bytes([0, 0])
+            return func(*args, **kwargs)
+
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=fake_executor_job)
+
+        with patch("custom_components.thz.dt_util", fake_dt_util), \
+             patch("os.path.isfile", return_value=True), \
+             patch("builtins.open", side_effect=fake_open):
+            handler = await self._get_handler(mock_hass)
+            call = MagicMock()
+            call.data = {
+                "filename": "thz_backup_x.json",
+                "only": ["HeatingCurve"],
+                "dry_run": False,
+            }
+            result = await handler(call)
+
+        assert result["success"] is True
+        assert result["restored"] == 1
+        assert result["failed_count"] == 0
+
+        # The write must have gone to the CURRENT map's command (0A0200),
+        # never the backup's stale one (0AFACE).
+        assert bytes.fromhex("0A0200") in written_commands
+        assert bytes.fromhex("0AFACE") not in written_commands
+
+    @pytest.mark.asyncio
+    async def test_no_backup_files_found_errors(self, mock_hass):
+        entry_data = self._entry_data()
+        mock_hass.data[DOMAIN]["entry_1"] = entry_data
+
+        async def fake_executor_job(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=fake_executor_job)
+
+        with patch("os.path.isdir", return_value=False):
+            handler = await self._get_handler(mock_hass)
+            call = MagicMock()
+            call.data = {}
+            result = await handler(call)
+
+        assert result["success"] is False
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_clock_never_restored_from_backup_value(self, mock_hass):
+        """pClock* entries in the backup are skipped; clock is synced to local time."""
+        entry_data = self._entry_data()
+        mock_hass.data[DOMAIN]["entry_1"] = entry_data
+        device = entry_data["device"]
+        backup_doc = self._backup_doc()
+        fake_dt_util, fake_open = self._patch_common(mock_hass, backup_doc, device)
+
+        clock_writes = []
+
+        async def fake_executor_job(func, *args, **kwargs):
+            if func is device.write_value:
+                clock_writes.append((args[0], args[1]))
+                return None
+            if func is device.read_value:
+                return bytes([0, 0])
+            return func(*args, **kwargs)
+
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=fake_executor_job)
+
+        with patch("custom_components.thz.dt_util", fake_dt_util), \
+             patch("os.path.isfile", return_value=True), \
+             patch("builtins.open", side_effect=fake_open):
+            handler = await self._get_handler(mock_hass)
+            call = MagicMock()
+            call.data = {"filename": "thz_backup_x.json", "only": [], "dry_run": False}
+            result = await handler(call)
+
+        assert result["clock_synced"] is True
+        # pClockYear command is 0A0101; its write value should reflect the
+        # local "now" year (26), not the backed-up value (also 26 here, but
+        # the point is it's driven by dt_util.now(), not backup_doc).
+        pclock_year_cmd = bytes.fromhex("0A0101")
+        matching = [w for w in clock_writes if w[0] == pclock_year_cmd]
+        assert matching, "expected a write to the pClockYear register"


### PR DESCRIPTION
Ports the backup_parameters, restore_parameters, and list_parameter_backups services plus the real-time clock drift handling (periodic 15-minute auto_sync_clock check, backup-time correction, restore-time sync) from the fork's main branch, rebuilt directly against upstream's simpler __init__.py structure rather than merged, since the two files had diverged too far for a mechanical merge.

Also fixes a bug found while porting: backup_parameters' clock-drift check previously read the device clock from a dict that filters out the pClock* registers (they're type "pclean", not one of the restorable entity types), so the check silently never ran. It now reads the clock directly via the same helper the periodic check uses.