### PR TITLE
Fix firmware-map fallback for unrecognized 4.3x firmware strings

### DIFF
--- a/custom_components/thz/register_maps/register_map_manager.py
+++ b/custom_components/thz/register_maps/register_map_manager.py
@@ -73,10 +73,22 @@ FIRMWARE_MAPS = {
         "write": ["write_map_439_539", "write_map_439"],
         "read": ["readings_map_439"],
     },
-    # default fallback is treated as 539-like
-    "default": {
+    # Real 5.39 hardware gets its own explicit entry (previously this was the
+    # only thing behind "default", conflating "genuine 5.39" with "unrecognized
+    # firmware string" below).
+    "539": {
         "write": ["write_map_439_539", "write_map_539"],
         "read": ["readings_map_439", "readings_map_539"],
+    },
+    # Fallback for any firmware string not listed above (e.g. "438", "437",
+    # "440" — off-by-a-point-release 4.3x builds we don't have a dedicated
+    # entry for). This mirrors the reference FHEM 00_THZ.pm module's own
+    # fallback ("in all other cases I assume $attrVal eq '4.39'", see
+    # docs/legacy/00_THZ.pm around line 2021) rather than guessing 5.39-like,
+    # which pulls in register offsets/fields that don't exist on 4.3x devices.
+    "default": {
+        "write": ["write_map_439_539", "write_map_439"],
+        "read": ["readings_map_439"],
     },
 }
 

--- a/tests/test_register_map_manager.py
+++ b/tests/test_register_map_manager.py
@@ -45,13 +45,31 @@ class TestFirmwareMaps:
         assert "readings_map_439" in config["read"]
 
     def test_539_firmware_config(self):
-        """Test default firmware configuration (539-like)."""
-        assert "default" in FIRMWARE_MAPS
-        config = FIRMWARE_MAPS["default"]
+        """Test explicit 539 firmware configuration (539-like)."""
+        assert "539" in FIRMWARE_MAPS
+        config = FIRMWARE_MAPS["539"]
         assert "write" in config
         assert "read" in config
         assert "write_map_539" in config["write"]
         assert "readings_map_539" in config["read"]
+
+    def test_default_firmware_config_is_439_like(self):
+        """Unrecognized firmware strings must fall back to 4.39-like maps.
+
+        Mirrors the reference FHEM 00_THZ.pm module, which treats any
+        unrecognized ``firmware`` attribute as 4.39 (see docs/legacy/00_THZ.pm,
+        "in all other cases I assume $attrVal eq '4.39'"). Falling back to
+        5.39-like maps instead pulls in register offsets/fields that don't
+        exist on 4.3x devices (e.g. firmware "438" on an LWZ 403).
+        """
+        assert "default" in FIRMWARE_MAPS
+        config = FIRMWARE_MAPS["default"]
+        assert "write" in config
+        assert "read" in config
+        assert "write_map_439" in config["write"]
+        assert "readings_map_439" in config["read"]
+        assert "write_map_539" not in config["write"]
+        assert "readings_map_539" not in config["read"]
 
     def test_technician_mode_configs(self):
         """Test technician mode firmware configurations."""
@@ -207,6 +225,18 @@ class TestBaseRegisterMapManager:
         # Should return default maps
         assert isinstance(write_maps, list)
         assert isinstance(read_maps, list)
+
+    def test_unrecognized_43x_firmware_uses_439_maps(self):
+        """Regression test: firmware "438" (LWZ 403, off-by-a-point-release
+        from the "439" entry) must load 439-style maps, not 539-style ones.
+        """
+        manager = RegisterMapManager("438")
+        assert "readings_map_439" in manager.readings_map_names
+        assert "readings_map_539" not in manager.readings_map_names
+
+        write_manager = RegisterMapManagerWrite("438")
+        assert "write_map_439" in write_manager.write_map_names
+        assert "write_map_539" not in write_manager.write_map_names
 
     def test_non_cooling_539_keeps_non_cooling_read_blocks(self):
         """Test non-cooling 5.39 keeps shared blocks and removes cooling-only ones."""


### PR DESCRIPTION
Firmware strings not explicitly listed in FIRMWARE_MAPS (e.g. "438", reported by some LWZ 403 units) fell through to a "default" entry that was really just the 5.39 register configuration, pulling in offsets and fields that don't exist on 4.3x hardware and causing garbage/wrong readings.

"539" now has its own explicit entry, and the fallback for unrecognized firmware strings uses the 4.39-style maps instead, matching FHEM's own 00_THZ.pm behavior ("in all other cases I assume firmware 4.39").

Adds a regression test for firmware "438" plus a corrected test for the now-explicit "539" entry.