### PR TITLE
Fix register-not-supported crash aborting whole config entry

### DIFF
--- a/custom_components/thz/__init__.py
+++ b/custom_components/thz/__init__.py
@@ -26,7 +26,7 @@ from .const import (
     WRITE_REGISTER_OFFSET,
     should_hide_entity_by_default,
 )
-from .thz_device import THZDevice
+from .thz_device import THZDevice, THZRegisterNotSupportedError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -779,6 +779,18 @@ async def _async_update_block(
                 result = bytes(buf)
 
             return result
+    except THZRegisterNotSupportedError:
+        # The device cleanly reported "register not supported" (01 04).
+        # Returning None (rather than raising) lets the caller's
+        # `if coordinator.data is None: unsupported_blocks.add(block)`
+        # handling — already written for exactly this case — actually run,
+        # instead of this one block's unsupported-ness taking down the
+        # whole config entry's first refresh.
+        _LOGGER.info(
+            "Register %s not supported by this device/firmware; skipping.",
+            block_name,
+        )
+        return None
     except Exception as err:  # noqa: BLE001
         raise UpdateFailed(f"Error reading {block_name}: {err}") from err
 

--- a/custom_components/thz/thz_device.py
+++ b/custom_components/thz/thz_device.py
@@ -610,6 +610,16 @@ class THZDevice:
                 raise THZRegisterNotSupportedError("Register not supported by device firmware")
             _LOGGER.error("Unknown response: %s", data.hex())
             return None
+        except THZRegisterNotSupportedError:
+            # Deliberately raised above for a clean "01 04" response — must
+            # propagate as-is so callers can treat it as "not supported by
+            # this firmware" rather than a generic decode failure. Catching
+            # it here (as the blanket except below used to) would silently
+            # downgrade it to a plain `None` return, indistinguishable from
+            # a genuine CRC/framing error, and callers further up would then
+            # raise a hard "Failed to decode device response" for a register
+            # that just isn't supported on this firmware/hardware.
+            raise
         except Exception as e:  # noqa: BLE001
             _LOGGER.error("Error decoding response: %s", e)
             return None

--- a/tests/test_async_update_block.py
+++ b/tests/test_async_update_block.py
@@ -1,0 +1,74 @@
+"""Tests for _async_update_block()'s handling of unsupported registers.
+
+Regression coverage for a bug where a device's clean "register not
+supported" response (THZRegisterNotSupportedError) was turned into a hard
+UpdateFailed instead of being treated as "no data for this block" — which
+crashed the whole config entry's first refresh (shown to the user as
+"Failed setup, will retry: Error reading <block>: Failed to decode device
+response") instead of just skipping that one unsupported block, as the
+caller in async_setup_entry already expects
+(``if coordinator.data is None: unsupported_blocks.add(block)``).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.thz.thz_device import THZRegisterNotSupportedError
+
+
+class TestAsyncUpdateBlock:
+    """Tests for _async_update_block()."""
+
+    @pytest.fixture
+    def mock_device(self):
+        """Create a mock THZ device with a real lock."""
+        device = MagicMock()
+        device.lock = asyncio.Lock()
+        return device
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock Home Assistant instance."""
+        return MagicMock()
+
+    @pytest.mark.asyncio
+    async def test_unsupported_register_returns_none(self, mock_hass, mock_device):
+        """A clean "not supported" response must not raise UpdateFailed."""
+        from custom_components.thz import _async_update_block
+
+        mock_hass.async_add_executor_job = AsyncMock(
+            side_effect=THZRegisterNotSupportedError("not supported")
+        )
+
+        result = await _async_update_block(mock_hass, mock_device, "pxx0A033B")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_genuine_decode_failure_raises_update_failed(
+        self, mock_hass, mock_device
+    ):
+        """A real decode/comms failure must still surface as UpdateFailed."""
+        from custom_components.thz import _async_update_block
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        mock_hass.async_add_executor_job = AsyncMock(
+            side_effect=RuntimeError("Failed to decode device response")
+        )
+
+        with pytest.raises(UpdateFailed):
+            await _async_update_block(mock_hass, mock_device, "pxx0A033B")
+
+    @pytest.mark.asyncio
+    async def test_successful_read_returns_result(self, mock_hass, mock_device):
+        """A normal successful read still returns the raw block bytes."""
+        from custom_components.thz import _async_update_block
+
+        test_data = bytes.fromhex("010a070503001234ff")
+        mock_hass.async_add_executor_job = AsyncMock(return_value=test_data)
+
+        result = await _async_update_block(mock_hass, mock_device, "pxxFB")
+
+        assert result == test_data

--- a/tests/test_thz_device.py
+++ b/tests/test_thz_device.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from custom_components.thz.thz_device import THZDevice
+from custom_components.thz.thz_device import THZDevice, THZRegisterNotSupportedError
 
 
 class TestTHZDeviceInitialization:
@@ -209,6 +209,66 @@ class TestFirmwareVersion:
     def test_firmware_version_none(self):
         """Test firmware_version raises error when not initialized."""
         device = THZDevice(connection="usb", port="/dev/null")
-        
+
         with pytest.raises(RuntimeError, match="Device not initialized"):
             _ = device.firmware_version
+
+
+class TestDecodeResponse:
+    """Tests for decode_response()'s protocol-error handling.
+
+    Regression coverage for a bug where a clean "01 04" (register not
+    supported) response was deliberately raised as
+    THZRegisterNotSupportedError, but then immediately swallowed by this
+    same method's own blanket ``except Exception`` and downgraded to a
+    plain ``None`` — indistinguishable from a genuine decode failure. That
+    caused registers the device doesn't support (e.g. 5.39-only registers
+    on 4.3x firmware) to crash the whole config entry's first refresh
+    instead of being skipped gracefully, one block at a time.
+    """
+
+    def test_register_not_supported_raises(self):
+        """Test that a "01 04" response raises THZRegisterNotSupportedError."""
+        device = THZDevice(connection="usb", port="/dev/null")
+        data = b"\x01\x04\x00\x00\x10\x03"
+
+        with pytest.raises(THZRegisterNotSupportedError):
+            device.decode_response(data)
+
+    def test_short_response_returns_none(self):
+        """Test that a too-short response returns None, not an exception."""
+        device = THZDevice(connection="usb", port="/dev/null")
+        assert device.decode_response(b"\x01\x00") is None
+
+    def test_timing_issue_returns_none(self):
+        """Test that a "01 01" (timing issue) response returns None."""
+        device = THZDevice(connection="usb", port="/dev/null")
+        assert device.decode_response(b"\x01\x01\x00\x00\x10\x03") is None
+
+    def test_crc_error_in_request_returns_none(self):
+        """Test that a "01 02" (CRC error in request) response returns None."""
+        device = THZDevice(connection="usb", port="/dev/null")
+        assert device.decode_response(b"\x01\x02\x00\x00\x10\x03") is None
+
+    def test_unknown_command_returns_none(self):
+        """Test that a "01 03" (unknown command) response returns None."""
+        device = THZDevice(connection="usb", port="/dev/null")
+        assert device.decode_response(b"\x01\x03\x00\x00\x10\x03") is None
+
+    def test_unknown_response_header_returns_none(self):
+        """Test that a completely unrecognized header returns None."""
+        device = THZDevice(connection="usb", port="/dev/null")
+        assert device.decode_response(b"\xff\xff\x00\x00\x10\x03") is None
+
+    def test_bad_checksum_returns_none(self):
+        """Test that a normal-header response with a wrong CRC returns None."""
+        device = THZDevice(connection="usb", port="/dev/null")
+        # header 01 00, wrong crc byte (0x00), payload \xaa\xbb, footer 10 03
+        assert device.decode_response(b"\x01\x00\x00\xaa\xbb\x10\x03") is None
+
+    def test_valid_response_decodes_payload(self):
+        """Test that a well-formed, correctly-checksummed response decodes."""
+        device = THZDevice(connection="usb", port="/dev/null")
+        # header 01 00, correct crc (0x66) for payload \xaa\xbb, footer 10 03
+        result = device.decode_response(b"\x01\x00\x66\xaa\xbb\x10\x03")
+        assert result == b"\x66\xaa\xbb"


### PR DESCRIPTION
decode_response() deliberately raised THZRegisterNotSupportedError for a clean "01 04" (register not supported) response, but its own blanket except Exception caught that same exception immediately after and downgraded it to a plain None, indistinguishable from a genuine decode failure. That turned a register the device doesn't support (e.g. a 5.39-only register on 4.3x hardware) into "Failed setup, will retry: Error reading <block>: Failed to decode device response", aborting the whole config entry instead of just skipping that one block (the existing unsupported_blocks handling in async_setup_entry was already written for exactly this case).

Fixed by letting THZRegisterNotSupportedError propagate out of decode_response(), and having _async_update_block() catch it and return None for that block instead of raising UpdateFailed.