### PR TITLE
Fix orphaned-entity cleanup missing dangling config_entry_id references

### DIFF
--- a/custom_components/thz/__init__.py
+++ b/custom_components/thz/__init__.py
@@ -707,16 +707,33 @@ async def _async_migrate_disable_hidden_entities(
 async def _async_cleanup_orphaned_entities(hass: HomeAssistant) -> None:
     """Remove orphaned THZ entities from the entity registry.
 
-    Orphaned entities are those with platform="thz" but config_entry_id=None.
-    These can occur when the integration is deleted but HA doesn't fully clean up
-    the entity registry entries, leaving "ghost" entities with broken names.
+    An entity is orphaned if it has platform="thz" and its config_entry_id
+    either is None, or no longer refers to any config entry that actually
+    exists. Both cases can occur when the integration is deleted:
+
+    - config_entry_id=None: HA nulled the reference out (the case this
+      function originally handled).
+    - config_entry_id=<stale id>: HA left the entity pointing at the
+      now-deleted entry's id instead of nulling it. This is the more common
+      case in practice, and the original None-only check missed it entirely
+      -- the entity registry row (including its unique_id) survives every
+      "Delete integration" cycle, and the *next* time the integration is
+      added, entity_registry.async_get_or_create() matches the pre-existing
+      unique_id and silently reattaches to this same old, stale row instead
+      of creating a fresh one for the new config entry.
     """
     entity_reg = er.async_get(hass)
     orphaned_count = 0
 
     # Get all entities and filter for orphaned THZ entities
     for entity in list(entity_reg.entities.values()):
-        if entity.platform == "thz" and entity.config_entry_id is None:
+        if entity.platform != "thz":
+            continue
+        config_entry_id = entity.config_entry_id
+        is_orphaned = config_entry_id is None or (
+            hass.config_entries.async_get_entry(config_entry_id) is None
+        )
+        if is_orphaned:
             entity_reg.async_remove(entity.entity_id)
             _LOGGER.debug("Removed orphaned THZ entity: %s", entity.entity_id)
             orphaned_count += 1

--- a/tests/test_cleanup_orphaned_entities.py
+++ b/tests/test_cleanup_orphaned_entities.py
@@ -1,0 +1,123 @@
+"""Tests for _async_cleanup_orphaned_entities.
+
+Regression coverage for a real-world bug: an entity registry row survives
+"Delete integration" -> re-add cycles because Home Assistant leaves its
+config_entry_id pointing at the now-deleted entry's id instead of nulling it
+out. The original cleanup only checked for config_entry_id is None, so it
+never caught this -- the stale row (including its unique_id) got silently
+reattached on every subsequent setup instead of a fresh row being created
+for the new config entry.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.thz import _async_cleanup_orphaned_entities, er
+
+
+def _make_entity(entity_id, platform, config_entry_id):
+    entity = MagicMock()
+    entity.entity_id = entity_id
+    entity.platform = platform
+    entity.config_entry_id = config_entry_id
+    return entity
+
+
+class TestCleanupOrphanedEntities:
+    @pytest.mark.asyncio
+    async def test_removes_entity_with_none_config_entry_id(self):
+        """Original behavior: config_entry_id is None -> removed."""
+        entity = _make_entity("number.thz_foo", "thz", None)
+        registry = MagicMock()
+        registry.entities.values.return_value = [entity]
+        hass = MagicMock()
+        hass.config_entries.async_get_entry.return_value = MagicMock()
+
+        with patch.object(
+            er, "async_get", return_value=registry
+        ):
+            await _async_cleanup_orphaned_entities(hass)
+
+        registry.async_remove.assert_called_once_with("number.thz_foo")
+
+    @pytest.mark.asyncio
+    async def test_removes_entity_with_dangling_config_entry_id(self):
+        """Regression: config_entry_id points at a deleted entry -> removed.
+
+        This is the case the original None-only check missed -- Home
+        Assistant left config_entry_id set to the old entry's id rather than
+        nulling it, so the entity looked "owned" and was never cleaned up.
+        """
+        entity = _make_entity("number.thz_stale", "thz", "deleted_entry_id")
+        registry = MagicMock()
+        registry.entities.values.return_value = [entity]
+        hass = MagicMock()
+        # No config entry exists with this id anymore.
+        hass.config_entries.async_get_entry.return_value = None
+
+        with patch.object(
+            er, "async_get", return_value=registry
+        ):
+            await _async_cleanup_orphaned_entities(hass)
+
+        registry.async_remove.assert_called_once_with("number.thz_stale")
+        hass.config_entries.async_get_entry.assert_called_once_with(
+            "deleted_entry_id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_keeps_entity_with_valid_config_entry_id(self):
+        """An entity whose config_entry_id refers to a real, live entry is
+        left alone."""
+        entity = _make_entity("number.thz_live", "thz", "live_entry_id")
+        registry = MagicMock()
+        registry.entities.values.return_value = [entity]
+        hass = MagicMock()
+        hass.config_entries.async_get_entry.return_value = MagicMock()  # exists
+
+        with patch.object(
+            er, "async_get", return_value=registry
+        ):
+            await _async_cleanup_orphaned_entities(hass)
+
+        registry.async_remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ignores_entities_from_other_platforms(self):
+        """An orphaned-looking entity from a different platform is never
+        touched, even with a dangling config_entry_id."""
+        entity = _make_entity("sensor.other_thing", "some_other_platform", None)
+        registry = MagicMock()
+        registry.entities.values.return_value = [entity]
+        hass = MagicMock()
+        hass.config_entries.async_get_entry.return_value = None
+
+        with patch.object(
+            er, "async_get", return_value=registry
+        ):
+            await _async_cleanup_orphaned_entities(hass)
+
+        registry.async_remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mixed_batch_removes_only_orphaned_thz_entities(self):
+        """A realistic mixed batch: live thz entity kept, dangling thz
+        entity removed, non-thz entity untouched."""
+        live = _make_entity("number.thz_live", "thz", "live_entry_id")
+        stale = _make_entity("number.thz_stale", "thz", "deleted_entry_id")
+        other = _make_entity("sensor.other", "voip", None)
+        registry = MagicMock()
+        registry.entities.values.return_value = [live, stale, other]
+        hass = MagicMock()
+
+        def fake_get_entry(entry_id):
+            return MagicMock() if entry_id == "live_entry_id" else None
+
+        hass.config_entries.async_get_entry.side_effect = fake_get_entry
+
+        with patch.object(
+            er, "async_get", return_value=registry
+        ):
+            await _async_cleanup_orphaned_entities(hass)
+
+        registry.async_remove.assert_called_once_with("number.thz_stale")


### PR DESCRIPTION
_async_cleanup_orphaned_entities only removed a stale THZ entity registry row when config_entry_id is None. Home Assistant doesn't reliably null that field out on integration deletion -- it can leave the entity pointing at the now-deleted config entry's old id instead. The None-only check missed this case entirely, so the stale row (and its unique_id) silently reattached on every subsequent setup, permanently freezing that entity's entity_id, since suggested_object_id is only consulted the first time a row is created for a given unique_id.

Now also treats an entity as orphaned when its config_entry_id doesn't match any config entry that currently exists.

Adds tests/test_cleanup_orphaned_entities.py: none-id removed (original behavior), dangling-id removed (the regression case), valid-id kept, other-platform entities ignored, and a mixed batch.