### PR TITLE
Fix climate Mode/Preset controls to actually work, use real op-mode names

### DIFF
--- a/custom_components/thz/climate.py
+++ b/custom_components/thz/climate.py
@@ -20,9 +20,18 @@ entities are created when the required data blocks are available:
 All HC entities expose:
 
 - ``hvac_action`` (HEATING / COOLING / IDLE) when ``pxx0A0176`` is available.
-- ``preset_mode`` (comfort / sleep / away) when ``pOpMode`` is writable.
+- ``preset_mode`` when ``pOpMode`` is writable, using the device's own
+  operating-mode names (``automatic``/``DAYmode``/``DHWmode``/``emergency``/
+  ``manual``/``setback``/``standby`` -- see ``SELECT_MAP["2opmode"]`` in
+  value_maps.py, matching FHEM's ``%OpMode`` in docs/legacy/00_THZ.pm)
+  instead of HA's generic comfort/sleep/away vocabulary.
 - HC1 additionally exposes ``fan_mode`` (off / low / medium / high) when
   ``p07FanStageDay`` is writable.
+
+``hvac_mode`` only ever offers ``HEAT`` (plus ``COOL`` when the device
+supports active cooling) -- there is no working ``OFF`` for an individual
+circuit. The heat pump's only real "off" is the global ``pOpMode`` standby
+state, which is already reachable through ``preset_mode``.
 
 For firmware versions that do not include writable setpoint commands (e.g.
 older 2.06 maps that omit the ``command`` field) the entity is created in
@@ -39,9 +48,6 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
-    PRESET_AWAY,
-    PRESET_COMFORT,
-    PRESET_SLEEP,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PRECISION_TENTHS, UnitOfTemperature
@@ -54,6 +60,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DOMAIN, WRITE_REGISTER_LENGTH, WRITE_REGISTER_OFFSET
 from .value_codec import THZValueCodec, decode_raw_value
+from .value_maps import SELECT_MAP
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,6 +83,15 @@ _HC2_COOL_SETPOINT_NAME = "p99CoolingHC2SetTemp"
 _OPMODE_NAME = "pOpMode"
 _FAN_STAGE_DAY_NAME = "p07FanStageDay"
 
+# decode_type key for pOpMode in SELECT_MAP (value_maps.py) -- the device's
+# own global operating-mode names ("standby", "automatic", "DAYmode",
+# "setback", "DHWmode", "manual", "emergency"), matching FHEM's %OpMode in
+# docs/legacy/00_THZ.pm. Used directly as HA preset_mode values below instead
+# of translating into HA's generic comfort/sleep/away vocabulary, so the
+# dashboard shows the same names this device (and FHEM before it) always
+# used.
+_OPMODE_DECODE_TYPE = "2opmode"
+
 # OpModeHC string value → HVACMode
 _OP_MODE_TO_HVAC: dict[str, HVACMode] = {
     "normal": HVACMode.HEAT,
@@ -87,19 +103,6 @@ _OP_MODE_TO_HVAC: dict[str, HVACMode] = {
 # Default temperature bounds used when no write entry is available
 _DEFAULT_MIN_TEMP = 10.0
 _DEFAULT_MAX_TEMP = 60.0
-
-# Preset mode: HA preset name → pOpMode device option string
-_PRESET_TO_OPMODE: dict[str, str] = {
-    PRESET_COMFORT: "DAYmode",
-    PRESET_SLEEP: "setback",
-    PRESET_AWAY: "standby",
-}
-# hcOpMode device option string → HA preset name
-_HC_OPMODE_TO_PRESET: dict[str, str] = {
-    "normal": PRESET_COMFORT,
-    "setback": PRESET_SLEEP,
-    "standby": PRESET_AWAY,
-}
 
 # Fan stage ↔ HA fan mode names  (stage 0 = off/bypass, 1–3 = low/medium/high)
 _FAN_MODES: list[str] = ["off", "low", "medium", "high"]
@@ -524,6 +527,7 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
         self._opmode_entry = opmode_entry
         self._fan_stage_entry = fan_stage_entry
         self._fan_stage_cache: int | None = None
+        self._op_mode_cache: str | None = None
 
         self._attr_translation_key = translation_key
 
@@ -531,14 +535,21 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
         safe_key = translation_key.lower().replace(" ", "_")
         self._attr_unique_id = f"thz_{device_id}_climate_{safe_key}"
 
-        # Determine supported HVAC modes and features
+        # Determine supported HVAC modes and features.
+        #
+        # OFF is deliberately not offered: this entity has no way to actually
+        # turn a single circuit off. Without cooling support, HEAT/OFF would
+        # both be pure no-ops (see async_set_hvac_mode). With cooling support,
+        # OFF would only ever disable the cooling switch -- not stop heating.
+        # The device's real "off" is the global pOpMode standby state, which
+        # is exposed via preset_mode instead.
         self._supports_cooling = (
             cool_switch_entry is not None and cool_setpoint_entry is not None
         )
         if self._supports_cooling:
-            self._attr_hvac_modes = [HVACMode.HEAT, HVACMode.COOL, HVACMode.OFF]
+            self._attr_hvac_modes = [HVACMode.HEAT, HVACMode.COOL]
         else:
-            self._attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
+            self._attr_hvac_modes = [HVACMode.HEAT]
 
         # TARGET_TEMPERATURE feature is available whenever we have a heat
         # setpoint command OR cooling is supported (then both heat/cool temps
@@ -550,7 +561,12 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
 
         if opmode_entry is not None:
             self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
-            self._attr_preset_modes = [PRESET_COMFORT, PRESET_SLEEP, PRESET_AWAY]
+            # Use the device's own mode names directly (sorted the same way
+            # FHEM's setList did: case-insensitively) instead of mapping onto
+            # HA's generic comfort/sleep/away presets.
+            self._attr_preset_modes = sorted(
+                SELECT_MAP[_OPMODE_DECODE_TYPE].values(), key=str.lower
+            )
 
         if fan_stage_entry is not None:
             self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
@@ -589,6 +605,10 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
         # Populate the fan stage cache on startup
         if self._fan_stage_entry is not None:
             await self._async_read_fan_stage()
+
+        # Populate the global operating-mode (pOpMode) cache on startup
+        if self._opmode_entry is not None:
+            await self._async_read_op_mode()
 
     @callback
     def _handle_cooling_coordinator_update(self) -> None:
@@ -720,23 +740,24 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def preset_mode(self) -> str | None:
-        """Return the current preset mode.
+        """Return the current global operating mode (pOpMode).
 
-        Maps the HC op-mode from coordinator data to a HA preset name:
-        ``normal`` → ``comfort``, ``setback`` → ``sleep``,
-        ``standby`` → ``away``.
+        This reflects the last known value of the ``pOpMode`` register itself
+        (cached via ``_async_read_op_mode``), using the device's own mode
+        name -- e.g. ``"DAYmode"``, ``"setback"``, ``"standby"``,
+        ``"automatic"``, ``"DHWmode"``, ``"manual"``, or ``"emergency"``. Note
+        this is a device-wide setting shared by HC1, HC2, and DHW alike (not
+        derived from this entity's own per-circuit ``hcOpMode``/``dhwOpMode``
+        block, which only distinguishes normal/setback/standby/restart and
+        can't represent all seven pOpMode states).
 
         Returns:
-            Current preset name, or ``None`` if unavailable or unsupported.
+            Current operating-mode name, or ``None`` if unavailable or
+            unsupported.
         """
         if self._opmode_entry is None:
             return None
-        if self.coordinator.data is None:
-            return None
-        op_str = _read_op_mode_raw(
-            self.coordinator.data, self._op_mode_offset, self._op_mode_length
-        )
-        return _HC_OPMODE_TO_PRESET.get(op_str or "", None)
+        return self._op_mode_cache
 
     @property
     def fan_mode(self) -> str | None:
@@ -779,10 +800,11 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
 
         - ``COOL``: enables the cooling switch (only available when the
           write-register map contains the cooling entries).
-        - ``HEAT`` / ``OFF``: disables the cooling switch (if present).
-          Switching the global operating mode off is intentionally not
-          supported here because ``pOpMode`` is a device-level register
-          shared by both heating circuits and DHW.
+        - ``HEAT``: disables the cooling switch (if present).
+
+        ``OFF`` is not offered in ``hvac_modes`` -- there is no per-circuit
+        "off" on this device; use ``preset_mode`` (``"standby"``) instead,
+        which writes the actual global ``pOpMode`` register.
 
         Args:
             hvac_mode: The requested :class:`HVACMode`.
@@ -799,47 +821,47 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
                 await self._cooling_coordinator.async_request_refresh()
             await self.coordinator.async_request_refresh()
 
-        elif hvac_mode in (HVACMode.HEAT, HVACMode.OFF):
+        elif hvac_mode == HVACMode.HEAT:
             if self._supports_cooling:
                 await self._async_set_cooling_switch(enabled=False)
-            if hvac_mode == HVACMode.OFF:
-                _LOGGER.info(
-                    "OFF mode requested on %s — switching to OFF requires changing "
-                    "the global pOpMode register which is not yet supported; "
-                    "cooling has been disabled.",
-                    self.name,
-                )
             await self.coordinator.async_request_refresh()
 
+        else:
+            _LOGGER.warning(
+                "Unsupported hvac_mode '%s' requested for %s", hvac_mode, self.name
+            )
+
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        """Set the preset operating mode.
+        """Set the global operating mode (pOpMode).
 
-        Writes the global ``pOpMode`` register with the device value that
-        corresponds to the requested HA preset:
-
-        - ``comfort`` → ``DAYmode`` (full heat / day schedule)
-        - ``sleep``   → ``setback`` (reduced setback temperature)
-        - ``away``    → ``standby`` (minimal / standby mode)
+        ``preset_mode`` is one of the device's own mode names (see
+        ``_attr_preset_modes``, sourced from ``SELECT_MAP["2opmode"]``) and is
+        written to the ``pOpMode`` register as-is -- no translation table
+        needed, since these already are the device's real option strings.
 
         Args:
-            preset_mode: One of ``comfort``, ``sleep``, or ``away``.
+            preset_mode: One of ``automatic``, ``DAYmode``, ``DHWmode``,
+                ``emergency``, ``manual``, ``setback``, or ``standby``.
         """
         if self._opmode_entry is None:
             return
-        opmode_str = _PRESET_TO_OPMODE.get(preset_mode)
-        if opmode_str is None:
+        if preset_mode not in (self._attr_preset_modes or []):
             _LOGGER.warning(
                 "Unknown preset mode '%s' for %s", preset_mode, self.name
             )
             return
         try:
-            value_bytes = THZValueCodec.encode_select(opmode_str, "2opmode")
+            value_bytes = THZValueCodec.encode_select(
+                preset_mode, _OPMODE_DECODE_TYPE
+            )
             async with self._device.lock:
                 await self.hass.async_add_executor_job(
                     self._device.write_value,
                     bytes.fromhex(self._opmode_entry["command"]),
                     value_bytes,
                 )
+            self._op_mode_cache = preset_mode
+            self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
         except (ValueError, TypeError, RuntimeError, ConnectionError, OSError) as err:
             _LOGGER.error(
@@ -1037,6 +1059,32 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
         except (ValueError, TypeError, RuntimeError, ConnectionError, OSError) as err:
             _LOGGER.warning(
                 "Could not read fan stage for %s: %s", self.name, err
+            )
+
+    async def _async_read_op_mode(self) -> None:
+        """Read and cache the current global operating mode (pOpMode)."""
+        if self._opmode_entry is None:
+            return
+        entry = self._opmode_entry
+        try:
+            async with self._device.lock:
+                value_bytes = await self.hass.async_add_executor_job(
+                    self._device.read_value,
+                    bytes.fromhex(entry["command"]),
+                    "get",
+                    WRITE_REGISTER_OFFSET,
+                    WRITE_REGISTER_LENGTH,
+                )
+            if value_bytes:
+                self._op_mode_cache = THZValueCodec.decode_select(
+                    value_bytes, _OPMODE_DECODE_TYPE
+                )
+                _LOGGER.debug(
+                    "Cached operating mode for %s: %s", self.name, self._op_mode_cache
+                )
+        except (ValueError, TypeError, RuntimeError, ConnectionError, OSError) as err:
+            _LOGGER.warning(
+                "Could not read operating mode for %s: %s", self.name, err
             )
 
     # ── Device registry ─────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,8 @@ class MockClimateEntityFeature:
     """Minimal ClimateEntityFeature stand-in that supports the | operator."""
     TARGET_TEMPERATURE = 1
     TARGET_TEMPERATURE_RANGE = 2
+    FAN_MODE = 8
+    PRESET_MODE = 16
 
     def __init__(self, value=0):
         """Initialise with a numeric feature bitmask."""

--- a/tests/test_climate_opmode_preset.py
+++ b/tests/test_climate_opmode_preset.py
@@ -1,0 +1,221 @@
+"""Tests for THZClimate's hvac_mode/preset_mode handling around the global
+pOpMode register.
+
+Regression coverage for two related bugs:
+
+1. ``hvac_modes`` used to include ``OFF``, but there is no way to actually
+   turn a single heating circuit off on this device -- without cooling
+   support HEAT/OFF were both pure no-ops, and with cooling support OFF only
+   ever disabled the cooling switch (never stopped heating). ``OFF`` is no
+   longer offered; the device's real "off" is the global ``pOpMode``
+   standby state, reachable via ``preset_mode``.
+
+2. ``preset_mode`` used to be inferred from each circuit's own
+   ``hcOpMode``/``dhwOpMode`` readback, mapped onto HA's generic
+   comfort/sleep/away vocabulary -- which only covered 3 of the device's 7
+   real operating-mode states, and read from a register that doesn't
+   necessarily track what was actually written to ``pOpMode``.
+   ``preset_mode`` now reads/writes the ``pOpMode`` register (0A0112)
+   directly, using the device's own state names from
+   ``SELECT_MAP["2opmode"]``.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.thz.climate import THZClimate, _OPMODE_DECODE_TYPE
+from custom_components.thz.value_maps import SELECT_MAP
+
+
+def _make_entity(
+    *,
+    cool_switch_entry=None,
+    cool_setpoint_entry=None,
+    opmode_entry=None,
+):
+    """Instantiate a minimal THZClimate (HC1-style) for direct unit testing."""
+    coordinator = MagicMock()
+    coordinator.data = None
+
+    device = MagicMock()
+    device.lock = asyncio.Lock()
+
+    entity = THZClimate(
+        coordinator=coordinator,
+        cooling_coordinator=None,
+        device=device,
+        device_id="test_device",
+        translation_key="Heating Circuit 1",
+        current_temp_offset=0,
+        current_temp_length=2,
+        target_temp_offset=2,
+        target_temp_length=2,
+        op_mode_offset=24,
+        op_mode_length=1,
+        heat_setpoint_entry={"command": "0A0080", "min": "10", "max": "30"},
+        cool_switch_entry=cool_switch_entry,
+        cool_setpoint_entry=cool_setpoint_entry,
+        opmode_entry=opmode_entry,
+    )
+    entity.hass = MagicMock()
+    entity.name = "Test Entity"
+    return entity
+
+
+_OPMODE_ENTRY = {"command": "0A0112"}
+_COOL_SWITCH_ENTRY = {"command": "0B0613"}
+_COOL_SETPOINT_ENTRY = {"command": "0B0582", "min": "12", "max": "27"}
+
+
+class TestHvacModesExcludeOff:
+    """OFF must never be offered -- there is no working per-circuit off."""
+
+    def test_heat_only_without_cooling(self):
+        entity = _make_entity()
+        assert entity.hvac_modes == [entity.hvac_modes[0]]  # single entry
+        assert "off" not in [m.value if hasattr(m, "value") else m for m in entity.hvac_modes]
+        from homeassistant.components.climate import HVACMode
+        assert entity.hvac_modes == [HVACMode.HEAT]
+
+    def test_heat_and_cool_when_cooling_supported(self):
+        from homeassistant.components.climate import HVACMode
+        entity = _make_entity(
+            cool_switch_entry=_COOL_SWITCH_ENTRY,
+            cool_setpoint_entry=_COOL_SETPOINT_ENTRY,
+        )
+        assert entity.hvac_modes == [HVACMode.HEAT, HVACMode.COOL]
+        assert HVACMode.OFF not in entity.hvac_modes
+
+
+class TestPresetModesFromSelectMap:
+    """preset_modes must be exactly the device's own 2opmode option names."""
+
+    def test_preset_modes_are_all_seven_device_states(self):
+        entity = _make_entity(opmode_entry=_OPMODE_ENTRY)
+        expected = sorted(SELECT_MAP[_OPMODE_DECODE_TYPE].values(), key=str.lower)
+        preset_modes = entity._attr_preset_modes
+        assert preset_modes == expected
+        assert len(preset_modes) == 7
+        assert "standby" in preset_modes
+        assert "DAYmode" in preset_modes
+        # The old HA-generic vocabulary must be gone.
+        assert "comfort" not in preset_modes
+        assert "sleep" not in preset_modes
+        assert "away" not in preset_modes
+
+    def test_no_preset_modes_without_opmode_entry(self):
+        entity = _make_entity()
+        assert entity.preset_mode is None
+
+
+class TestPresetModeProperty:
+    """preset_mode reflects the cached pOpMode value, not per-circuit state."""
+
+    def test_returns_none_before_first_read(self):
+        entity = _make_entity(opmode_entry=_OPMODE_ENTRY)
+        assert entity.preset_mode is None
+
+    def test_returns_cached_value(self):
+        entity = _make_entity(opmode_entry=_OPMODE_ENTRY)
+        entity._op_mode_cache = "DAYmode"
+        assert entity.preset_mode == "DAYmode"
+
+
+class TestAsyncSetPresetMode:
+    @pytest.mark.asyncio
+    async def test_writes_device_native_value_and_updates_cache(self):
+        entity = _make_entity(opmode_entry=_OPMODE_ENTRY)
+        entity.async_write_ha_state = MagicMock()
+        entity.coordinator.async_request_refresh = AsyncMock()
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+
+        await entity.async_set_preset_mode("standby")
+
+        assert entity._op_mode_cache == "standby"
+        entity.async_write_ha_state.assert_called_once()
+        entity.hass.async_add_executor_job.assert_called_once()
+        # No translation table involved -- the write value is the encoded
+        # "standby" option itself.
+        call_args = entity.hass.async_add_executor_job.call_args
+        assert call_args[0][0] == entity._device.write_value
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_preset(self):
+        entity = _make_entity(opmode_entry=_OPMODE_ENTRY)
+        entity.hass.async_add_executor_job = AsyncMock()
+
+        # "comfort" was a valid preset under the old HA vocabulary; it is not
+        # a real pOpMode option and must be rejected now.
+        await entity.async_set_preset_mode("comfort")
+
+        entity.hass.async_add_executor_job.assert_not_called()
+        assert entity._op_mode_cache is None
+
+    @pytest.mark.asyncio
+    async def test_noop_without_opmode_entry(self):
+        entity = _make_entity()
+        entity.hass.async_add_executor_job = AsyncMock()
+
+        await entity.async_set_preset_mode("standby")
+
+        entity.hass.async_add_executor_job.assert_not_called()
+
+
+class TestAsyncSetHvacMode:
+    @pytest.mark.asyncio
+    async def test_heat_disables_cooling_switch_when_supported(self):
+        from homeassistant.components.climate import HVACMode
+
+        entity = _make_entity(
+            cool_switch_entry=_COOL_SWITCH_ENTRY,
+            cool_setpoint_entry=_COOL_SETPOINT_ENTRY,
+        )
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        await entity.async_set_hvac_mode(HVACMode.HEAT)
+
+        entity.coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_off_is_not_a_supported_mode(self):
+        """OFF is no longer in hvac_modes; requesting it must not crash and
+        must not silently reinterpret it as anything else."""
+        from homeassistant.components.climate import HVACMode
+
+        entity = _make_entity()
+        entity.hass.async_add_executor_job = AsyncMock()
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        await entity.async_set_hvac_mode(HVACMode.OFF)
+
+        # Neither a cooling-switch write nor a refresh should happen for an
+        # unsupported mode.
+        entity.hass.async_add_executor_job.assert_not_called()
+        entity.coordinator.async_request_refresh.assert_not_called()
+
+
+class TestAsyncAddedToHassReadsOpMode:
+    @pytest.mark.asyncio
+    async def test_reads_op_mode_on_startup_when_entry_present(self):
+        entity = _make_entity(opmode_entry=_OPMODE_ENTRY)
+        entity.hass.async_add_executor_job = AsyncMock(
+            return_value=bytes([1, 0])  # "1" -> "standby" per SELECT_MAP
+        )
+        entity.async_on_remove = MagicMock()
+
+        await entity._async_read_op_mode()
+
+        assert entity._op_mode_cache == "standby"
+
+    @pytest.mark.asyncio
+    async def test_noop_without_opmode_entry(self):
+        entity = _make_entity()
+        entity.hass.async_add_executor_job = AsyncMock()
+
+        await entity._async_read_op_mode()
+
+        entity.hass.async_add_executor_job.assert_not_called()
+        assert entity._op_mode_cache is None


### PR DESCRIPTION
hvac_mode: remove OFF from hvac_modes entirely. It was a pure no-op -- without cooling support it did nothing at all, and with cooling support it only disabled the cooling switch (never actually stopped heating). There is no per-circuit off on this device; the real off is the global pOpMode standby state, now reachable via preset_mode.

preset_mode: read/write the pOpMode register directly (0A0112) instead of inferring from each circuit's own hcOpMode/dhwOpMode readback. Now exposes all 7 real device states (automatic/DAYmode/DHWmode/emergency/ manual/setback/standby, per SELECT_MAP["2opmode"]) using the device's own names, instead of HA's generic comfort/sleep/away vocabulary, which only covered 3 of the 7 states and read from a register that doesn't necessarily track what was written.

BREAKING CHANGE: any automation, script, or dashboard referencing the old comfort/sleep/away preset_mode values, or the off hvac_mode, on this integration's climate entities will need to be updated.

Also fixes tests/conftest.py's MockClimateEntityFeature, which was missing PRESET_MODE and FAN_MODE even though climate.py uses both -- a pre-existing gap that meant this behavior could never be properly tested.

Adds tests/test_climate_opmode_preset.py (13 tests): hvac_modes never include OFF, preset_modes is exactly the 7 device states, preset_mode reflects the cache, set_preset_mode writes correctly and rejects unknown/old-vocabulary presets, set_hvac_mode(OFF) is a safe no-op, and the op-mode cache populates on startup.