### PR TITLE
Fix/climate manual setpoint

### DIFF
--- a/custom_components/thz/climate.py
+++ b/custom_components/thz/climate.py
@@ -5,13 +5,20 @@ entities are created when the required data blocks are available:
 
 - **Heating Circuit 1 (HC1)**: reads current / target room temperature from
   the ``pxxF4`` coordinator.  HC1 has independently-scheduled day
-  (``p01RoomTempDayHC1``) and night (``p02RoomTempNightHC1``) setpoints; the
-  device itself decides which one is active at any given moment. Setting a
-  new temperature reads both registers fresh and writes to whichever one
-  currently matches the live ``roomSetTemp`` reading, so the change actually
-  takes effect regardless of whether day or night mode is currently active
-  (falls back to the day register if neither matches closely enough, e.g.
-  right at a day/night transition). When the write-register map contains both
+  (``p01RoomTempDayHC1``) and night (``p02RoomTempNightHC1``) *room*
+  setpoints; the device itself decides which one is active at any given
+  moment (AUTOMATIC mode follows the time program, DAY MODE/SETBACK MODE
+  force one or the other). Setting a new temperature reads both registers
+  fresh and writes to whichever one currently matches the live
+  ``roomSetTemp`` reading, so the change actually takes effect regardless of
+  whether day or setback is currently active (falls back to the day register
+  if neither matches, e.g. right at a transition). Note: the device's global
+  MANUAL MODE sets a *flow* temperature directly (``MANUAL SET HC`` in the
+  operating manual), bypassing the weather-compensated curve entirely --
+  that is a different physical quantity from the room-temperature day/night
+  setpoints this entity manages, not a third candidate for the matching
+  above, and isn't handled by this entity. When the write-register map
+  contains both
   ``p99CoolingHC1Switch`` and ``p99CoolingHC1SetTemp`` (present on devices
   that support active cooling), the entity also exposes ``COOL`` mode.
   Cooling-active status is read from the ``pxx0A0176`` coordinator
@@ -28,8 +35,11 @@ entities are created when the required data blocks are available:
 - **Domestic Hot Water (DHW)**: reads current / target water temperature from
   the ``pxxF3`` coordinator and supports ``HEAT`` mode only.  Like HC1, DHW
   has independently-scheduled day (``p04DHWsetDayTemp``) and night
-  (``p05DHWsetNightTemp``) setpoints, and setting a new temperature writes to
-  whichever register is currently active, using the same logic as HC1.
+  (``p05DHWsetNightTemp``) setpoints, plus a distinct manual-mode setpoint
+  (``p11DHWsetManualTemp``) that -- unlike HC1's manual register -- *is*
+  present on 439/539-series maps. Setting a new temperature writes to
+  whichever of the three registers is currently active, using the same
+  logic as HC1.
 
 All HC entities expose:
 
@@ -78,6 +88,7 @@ _HC1_HEAT_SETPOINT_NAMES = ["p01RoomTempDayHC1", "p01RoomTempDay"]
 _HC1_NIGHT_SETPOINT_NAMES = ["p02RoomTempNightHC1", "p02RoomTempNight"]
 _DHW_SETPOINT_NAMES = ["p04DHWsetDayTemp", "p04DHWsetTempDay"]
 _DHW_NIGHT_SETPOINT_NAMES = ["p05DHWsetNightTemp", "p05DHWsetTempNight"]
+_DHW_MANUAL_SETPOINT_NAMES = ["p11DHWsetManualTemp", "p11DHWsetTempManual"]
 
 # Write-register names for HC1 cooling (present on devices with active cooling support)
 _HC1_COOL_SWITCH_NAME = "p99CoolingHC1Switch"
@@ -342,6 +353,7 @@ async def async_setup_entry(
         else:
             dhw_entry = _find_entry(write_registers, _DHW_SETPOINT_NAMES)
             dhw_night_entry = _find_entry(write_registers, _DHW_NIGHT_SETPOINT_NAMES)
+            dhw_manual_entry = _find_entry(write_registers, _DHW_MANUAL_SETPOINT_NAMES)
             entities.append(
                 THZClimate(
                     coordinator=dhw_coordinator,
@@ -357,6 +369,7 @@ async def async_setup_entry(
                     op_mode_length=f3_opmode[1],
                     heat_setpoint_entry=dhw_entry,
                     night_setpoint_entry=dhw_night_entry,
+                    manual_setpoint_entry=dhw_manual_entry,
                     cool_switch_entry=None,
                     cool_setpoint_entry=None,
                 )
@@ -497,6 +510,7 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
         cooling_bit: int | None = None,
         compressor_bit: int | None = None,
         night_setpoint_entry: dict | None = None,
+        manual_setpoint_entry: dict | None = None,
     ) -> None:
         """Initialise a THZ climate entity.
 
@@ -536,6 +550,7 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
 
         self._heat_setpoint_entry = heat_setpoint_entry
         self._night_setpoint_entry = night_setpoint_entry
+        self._manual_setpoint_entry = manual_setpoint_entry
         self._cool_switch_entry = cool_switch_entry
         self._cool_setpoint_entry = cool_setpoint_entry
         self._cooling_byte = cooling_byte
@@ -933,29 +948,48 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
     async def _async_write_heat_setpoint(self, temperature: float) -> None:
         """Write the heating setpoint that is currently driving roomSetTemp.
 
-        HC1/HC2/DHW each have independently-scheduled day/night setpoints;
-        the device itself decides which one is active. Always writing the
-        day register silently no-ops from the user's point of view whenever
-        night is the one actually in effect. Instead, read both registers
-        fresh and write to whichever one currently matches the live
-        roomSetTemp reading, falling back to day if neither matches closely
-        enough (e.g. right at a day/night transition).
+        HC1/HC2/DHW each have multiple independently-writable setpoint
+        registers -- day and night always, plus a distinct manual-mode
+        register on firmware maps that have one (e.g. DHW's
+        p11DHWsetManualTemp -- HC1/HC2 have no such register wired up here,
+        since their MANUAL MODE sets a flow temperature, a different
+        physical quantity from the room-temperature day/night setpoints,
+        not a valid matching candidate at all). The
+        device itself decides which register is currently in effect; always
+        writing the day register silently no-ops from the user's point of
+        view whenever a different one is actually active. Instead, read
+        every candidate register fresh and write to whichever single one
+        currently matches the live roomSetTemp/dhwTemp target reading,
+        falling back to day if none match unambiguously (e.g. right at a
+        day/night transition, or if the active mode uses a register this
+        integration doesn't know about).
 
         Args:
             temperature: Target temperature in °C.
         """
         active_temp = self.target_temperature
         day_entry = self._heat_setpoint_entry
-        night_entry = self._night_setpoint_entry
-        target_entry = day_entry
+        candidates: list[tuple[str, dict]] = []
+        if day_entry is not None:
+            candidates.append(("day", day_entry))
+        if self._night_setpoint_entry is not None:
+            candidates.append(("night", self._night_setpoint_entry))
+        if self._manual_setpoint_entry is not None:
+            candidates.append(("manual", self._manual_setpoint_entry))
 
-        if night_entry is not None and day_entry is not None and active_temp is not None:
-            day_value = await self._async_read_setpoint(day_entry)
-            night_value = await self._async_read_setpoint(night_entry)
-            day_matches = day_value is not None and abs(day_value - active_temp) < 0.05
-            night_matches = night_value is not None and abs(night_value - active_temp) < 0.05
-            if night_matches and not day_matches:
-                target_entry = night_entry
+        target_label, target_entry = "day", day_entry
+
+        if len(candidates) > 1 and active_temp is not None:
+            matches: list[tuple[str, dict]] = []
+            for label, entry in candidates:
+                value = await self._async_read_setpoint(entry)
+                if value is not None and abs(value - active_temp) < 0.05:
+                    matches.append((label, entry))
+            if len(matches) == 1:
+                target_label, target_entry = matches[0]
+            # 0 matches (active mode uses an unmapped register) or >1
+            # matches (day/night/manual values happen to coincide) are both
+            # ambiguous -- keep the day fallback rather than guess wrong.
 
         if target_entry is None:
             _LOGGER.warning(
@@ -969,8 +1003,7 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
 
         _LOGGER.debug(
             "Writing heat setpoint %.1f °C to %s (cmd=%s, step=%s, register=%s)",
-            temperature, self.name, target_entry["command"], step,
-            "night" if target_entry is night_entry else "day",
+            temperature, self.name, target_entry["command"], step, target_label,
         )
         try:
             value_bytes = THZValueCodec.encode_number(temperature, step, decode_type)

--- a/custom_components/thz/climate.py
+++ b/custom_components/thz/climate.py
@@ -4,7 +4,14 @@ This module provides climate entities for the THZ integration.  Two climate
 entities are created when the required data blocks are available:
 
 - **Heating Circuit 1 (HC1)**: reads current / target room temperature from
-  the ``pxxF4`` coordinator.  When the write-register map contains both
+  the ``pxxF4`` coordinator.  HC1 has independently-scheduled day
+  (``p01RoomTempDayHC1``) and night (``p02RoomTempNightHC1``) setpoints; the
+  device itself decides which one is active at any given moment. Setting a
+  new temperature reads both registers fresh and writes to whichever one
+  currently matches the live ``roomSetTemp`` reading, so the change actually
+  takes effect regardless of whether day or night mode is currently active
+  (falls back to the day register if neither matches closely enough, e.g.
+  right at a day/night transition). When the write-register map contains both
   ``p99CoolingHC1Switch`` and ``p99CoolingHC1SetTemp`` (present on devices
   that support active cooling), the entity also exposes ``COOL`` mode.
   Cooling-active status is read from the ``pxx0A0176`` coordinator
@@ -13,9 +20,16 @@ entities are created when the required data blocks are available:
 - **Heating Circuit 2 (HC2)**: reads target temperature from the ``pxxF5``
   coordinator.  Created only when ``p01RoomTempDayHC2`` is present in the
   write-register map.  No room-temperature sensor is available for HC2.
+  Like HC1, HC2 has independently-scheduled day/night setpoints
+  (``p01RoomTempDayHC2`` / ``p02RoomTempNightHC2``); setting a new
+  temperature writes to whichever register is currently active, using the
+  same logic as HC1.
 
 - **Domestic Hot Water (DHW)**: reads current / target water temperature from
-  the ``pxxF3`` coordinator and supports ``HEAT`` mode only.
+  the ``pxxF3`` coordinator and supports ``HEAT`` mode only.  Like HC1, DHW
+  has independently-scheduled day (``p04DHWsetDayTemp``) and night
+  (``p05DHWsetNightTemp``) setpoints, and setting a new temperature writes to
+  whichever register is currently active, using the same logic as HC1.
 
 All HC entities expose:
 
@@ -61,7 +75,9 @@ _TEMP_FACTOR = 10.0
 
 # Write-register name candidates for heat setpoints (tried in order)
 _HC1_HEAT_SETPOINT_NAMES = ["p01RoomTempDayHC1", "p01RoomTempDay"]
+_HC1_NIGHT_SETPOINT_NAMES = ["p02RoomTempNightHC1", "p02RoomTempNight"]
 _DHW_SETPOINT_NAMES = ["p04DHWsetDayTemp", "p04DHWsetTempDay"]
+_DHW_NIGHT_SETPOINT_NAMES = ["p05DHWsetNightTemp", "p05DHWsetTempNight"]
 
 # Write-register names for HC1 cooling (present on devices with active cooling support)
 _HC1_COOL_SWITCH_NAME = "p99CoolingHC1Switch"
@@ -69,6 +85,7 @@ _HC1_COOL_SETPOINT_NAME = "p99CoolingHC1SetTemp"
 
 # Write-register names for HC2
 _HC2_HEAT_SETPOINT_NAMES = ["p01RoomTempDayHC2"]
+_HC2_NIGHT_SETPOINT_NAMES = ["p02RoomTempNightHC2"]
 _HC2_COOL_SWITCH_NAME = "p99CoolingHC2Switch"
 _HC2_COOL_SETPOINT_NAME = "p99CoolingHC2SetTemp"
 
@@ -231,6 +248,7 @@ async def async_setup_entry(
             _LOGGER.error("Required fields missing from pxxF4 map; skipping HC1 climate entity")
         else:
             heat_entry = _find_entry(write_registers, _HC1_HEAT_SETPOINT_NAMES)
+            night_entry = _find_entry(write_registers, _HC1_NIGHT_SETPOINT_NAMES)
             cool_switch_entry = write_registers.get(_HC1_COOL_SWITCH_NAME)
             cool_setpoint_entry = write_registers.get(_HC1_COOL_SETPOINT_NAME)
 
@@ -264,6 +282,7 @@ async def async_setup_entry(
                     cooling_bit=a176_cooling[1] if a176_cooling else None,
                     compressor_bit=a176_compressor[1] if a176_compressor else None,
                     heat_setpoint_entry=heat_entry,
+                    night_setpoint_entry=night_entry,
                     cool_switch_entry=cool_switch_entry,
                     cool_setpoint_entry=cool_setpoint_entry,
                     opmode_entry=opmode_entry,
@@ -278,6 +297,7 @@ async def async_setup_entry(
             _LOGGER.error("Required fields missing from pxxF5 map; skipping HC2 climate entity")
         else:
             hc2_heat_entry = _find_entry(write_registers, _HC2_HEAT_SETPOINT_NAMES)
+            hc2_night_entry = _find_entry(write_registers, _HC2_NIGHT_SETPOINT_NAMES)
             if hc2_heat_entry is not None:
                 hc2_cool_switch_entry = write_registers.get(_HC2_COOL_SWITCH_NAME)
                 hc2_cool_setpoint_entry = write_registers.get(_HC2_COOL_SETPOINT_NAME)
@@ -307,6 +327,7 @@ async def async_setup_entry(
                         cooling_bit=a176_cooling[1] if a176_cooling else None,
                         compressor_bit=a176_compressor[1] if a176_compressor else None,
                         heat_setpoint_entry=hc2_heat_entry,
+                        night_setpoint_entry=hc2_night_entry,
                         cool_switch_entry=hc2_cool_switch_entry,
                         cool_setpoint_entry=hc2_cool_setpoint_entry,
                         opmode_entry=opmode_entry,
@@ -320,6 +341,7 @@ async def async_setup_entry(
             _LOGGER.error("Required fields missing from pxxF3 map; skipping DHW climate entity")
         else:
             dhw_entry = _find_entry(write_registers, _DHW_SETPOINT_NAMES)
+            dhw_night_entry = _find_entry(write_registers, _DHW_NIGHT_SETPOINT_NAMES)
             entities.append(
                 THZClimate(
                     coordinator=dhw_coordinator,
@@ -334,6 +356,7 @@ async def async_setup_entry(
                     op_mode_offset=f3_opmode[0],
                     op_mode_length=f3_opmode[1],
                     heat_setpoint_entry=dhw_entry,
+                    night_setpoint_entry=dhw_night_entry,
                     cool_switch_entry=None,
                     cool_setpoint_entry=None,
                 )
@@ -473,6 +496,7 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
         cooling_byte: int | None = None,
         cooling_bit: int | None = None,
         compressor_bit: int | None = None,
+        night_setpoint_entry: dict | None = None,
     ) -> None:
         """Initialise a THZ climate entity.
 
@@ -511,6 +535,7 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
         self._op_mode_length = op_mode_length
 
         self._heat_setpoint_entry = heat_setpoint_entry
+        self._night_setpoint_entry = night_setpoint_entry
         self._cool_switch_entry = cool_switch_entry
         self._cool_setpoint_entry = cool_setpoint_entry
         self._cooling_byte = cooling_byte
@@ -886,33 +911,73 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
 
     # ── Private write helpers ───────────────────────────────────────────────
 
+    async def _async_read_setpoint(self, entry: dict) -> float | None:
+        """Read a heat-setpoint register's current value directly from the device."""
+        step = _get_step(entry)
+        decode_type = entry.get("decode_type", "5temp")
+        try:
+            async with self._device.lock:
+                value_bytes = await self.hass.async_add_executor_job(
+                    self._device.read_value,
+                    bytes.fromhex(entry["command"]),
+                    "get",
+                    WRITE_REGISTER_OFFSET,
+                    WRITE_REGISTER_LENGTH,
+                )
+            if value_bytes:
+                return THZValueCodec.decode_number(value_bytes, step, decode_type)
+        except (ValueError, TypeError, RuntimeError, ConnectionError, OSError) as err:
+            _LOGGER.warning("Could not read setpoint register for %s: %s", self.name, err)
+        return None
+
     async def _async_write_heat_setpoint(self, temperature: float) -> None:
-        """Write the heating setpoint to the device.
+        """Write the heating setpoint that is currently driving roomSetTemp.
+
+        HC1/HC2/DHW each have independently-scheduled day/night setpoints;
+        the device itself decides which one is active. Always writing the
+        day register silently no-ops from the user's point of view whenever
+        night is the one actually in effect. Instead, read both registers
+        fresh and write to whichever one currently matches the live
+        roomSetTemp reading, falling back to day if neither matches closely
+        enough (e.g. right at a day/night transition).
 
         Args:
             temperature: Target temperature in °C.
         """
-        if self._heat_setpoint_entry is None:
+        active_temp = self.target_temperature
+        day_entry = self._heat_setpoint_entry
+        night_entry = self._night_setpoint_entry
+        target_entry = day_entry
+
+        if night_entry is not None and day_entry is not None and active_temp is not None:
+            day_value = await self._async_read_setpoint(day_entry)
+            night_value = await self._async_read_setpoint(night_entry)
+            day_matches = day_value is not None and abs(day_value - active_temp) < 0.05
+            night_matches = night_value is not None and abs(night_value - active_temp) < 0.05
+            if night_matches and not day_matches:
+                target_entry = night_entry
+
+        if target_entry is None:
             _LOGGER.warning(
                 "Cannot set heating setpoint on %s: no write command available",
                 self.name,
             )
             return
 
-        entry = self._heat_setpoint_entry
-        step = _get_step(entry)
-        decode_type = entry.get("decode_type", "5temp")
+        step = _get_step(target_entry)
+        decode_type = target_entry.get("decode_type", "5temp")
 
         _LOGGER.debug(
-            "Writing heat setpoint %.1f °C to %s (cmd=%s, step=%s)",
-            temperature, self.name, entry["command"], step,
+            "Writing heat setpoint %.1f °C to %s (cmd=%s, step=%s, register=%s)",
+            temperature, self.name, target_entry["command"], step,
+            "night" if target_entry is night_entry else "day",
         )
         try:
             value_bytes = THZValueCodec.encode_number(temperature, step, decode_type)
             async with self._device.lock:
                 await self.hass.async_add_executor_job(
                     self._device.write_value,
-                    bytes.fromhex(entry["command"]),
+                    bytes.fromhex(target_entry["command"]),
                     value_bytes,
                 )
             await self.coordinator.async_request_refresh()

--- a/tests/test_climate_day_night_setpoint.py
+++ b/tests/test_climate_day_night_setpoint.py
@@ -1,0 +1,198 @@
+"""Tests for THZClimate's day/night setpoint write logic.
+
+Regression coverage: HC1, HC2, and DHW each have independently-scheduled
+day and night setpoint registers (e.g. p01RoomTempDayHC1 /
+p02RoomTempNightHC1); the device itself decides which one is currently
+active and reports its value via roomSetTemp. The old code always wrote the
+day register, which silently no-op'd from the user's point of view whenever
+night mode was the one actually in effect -- the write would "succeed" but
+the device would keep using whatever the night register already held.
+_async_write_heat_setpoint now reads both registers fresh and writes to
+whichever one currently matches the live roomSetTemp reading, falling back
+to the day register if neither matches closely (e.g. right at a day/night
+transition) or if no night register is configured at all.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+
+from custom_components.thz.climate import THZClimate
+
+
+_DAY_ENTRY = {"command": "0A0080", "min": "10", "max": "30", "step": "0.1"}
+_NIGHT_ENTRY = {"command": "0A0081", "min": "10", "max": "30", "step": "0.1"}
+
+
+def _make_entity(*, heat_setpoint_entry=_DAY_ENTRY, night_setpoint_entry=None):
+    coordinator = MagicMock()
+    coordinator.data = None
+
+    device = MagicMock()
+    device.lock = asyncio.Lock()
+
+    entity = THZClimate(
+        coordinator=coordinator,
+        cooling_coordinator=None,
+        device=device,
+        device_id="test_device",
+        translation_key="Heating Circuit 1",
+        current_temp_offset=0,
+        current_temp_length=2,
+        target_temp_offset=2,
+        target_temp_length=2,
+        op_mode_offset=24,
+        op_mode_length=1,
+        heat_setpoint_entry=heat_setpoint_entry,
+        cool_switch_entry=None,
+        cool_setpoint_entry=None,
+        night_setpoint_entry=night_setpoint_entry,
+    )
+    entity.hass = MagicMock()
+    entity.name = "Test Entity"
+    # target_temperature reads from coordinator.data via _read_temp; patch it
+    # directly instead, since these tests care about setpoint selection, not
+    # temperature decoding.
+    return entity
+
+
+class TestWriteHeatSetpointWithoutNightRegister:
+    """No night register configured -- behaves exactly as before."""
+
+    @pytest.mark.asyncio
+    async def test_writes_day_register(self):
+        entity = _make_entity()
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        await entity._async_write_heat_setpoint(21.5)
+
+        entity.hass.async_add_executor_job.assert_called_once()
+        write_call = entity.hass.async_add_executor_job.call_args
+        assert write_call[0][0] == entity._device.write_value
+        assert write_call[0][1] == bytes.fromhex(_DAY_ENTRY["command"])
+
+    @pytest.mark.asyncio
+    async def test_warns_and_noops_with_no_entries_at_all(self):
+        entity = _make_entity(heat_setpoint_entry=None)
+        entity.hass.async_add_executor_job = AsyncMock()
+
+        await entity._async_write_heat_setpoint(21.5)
+
+        entity.hass.async_add_executor_job.assert_not_called()
+
+
+class TestWriteHeatSetpointWithNightRegister:
+    """Night register configured -- writes to whichever is currently active."""
+
+    @pytest.mark.asyncio
+    async def test_writes_night_register_when_night_is_active(self):
+        entity = _make_entity(night_setpoint_entry=_NIGHT_ENTRY)
+
+        async def fake_read_setpoint(entry):
+            if entry is _NIGHT_ENTRY:
+                return 18.0
+            return 21.0  # day register reads something different
+
+        entity._async_read_setpoint = fake_read_setpoint
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        # Live roomSetTemp reports 18.0 -- matches the night setpoint value.
+        with patch.object(
+            type(entity), "target_temperature", new_callable=PropertyMock
+        ) as mock_target_temp:
+            mock_target_temp.return_value = 18.0
+            await entity._async_write_heat_setpoint(17.0)
+
+        write_call = entity.hass.async_add_executor_job.call_args
+        assert write_call[0][1] == bytes.fromhex(_NIGHT_ENTRY["command"])
+
+    @pytest.mark.asyncio
+    async def test_writes_day_register_when_day_is_active(self):
+        entity = _make_entity(night_setpoint_entry=_NIGHT_ENTRY)
+
+        async def fake_read_setpoint(entry):
+            if entry is _NIGHT_ENTRY:
+                return 18.0
+            return 21.0
+
+        entity._async_read_setpoint = fake_read_setpoint
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        with patch.object(
+            type(entity), "target_temperature", new_callable=PropertyMock
+        ) as mock_target_temp:
+            mock_target_temp.return_value = 21.0
+            await entity._async_write_heat_setpoint(22.0)
+
+        write_call = entity.hass.async_add_executor_job.call_args
+        assert write_call[0][1] == bytes.fromhex(_DAY_ENTRY["command"])
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_day_when_neither_register_matches(self):
+        """At a day/night transition, or if reads fail, default to day."""
+        entity = _make_entity(night_setpoint_entry=_NIGHT_ENTRY)
+
+        async def fake_read_setpoint(entry):
+            if entry is _NIGHT_ENTRY:
+                return 18.0
+            return 21.0
+
+        entity._async_read_setpoint = fake_read_setpoint
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        with patch.object(
+            type(entity), "target_temperature", new_callable=PropertyMock
+        ) as mock_target_temp:
+            mock_target_temp.return_value = 19.5  # matches neither register
+            await entity._async_write_heat_setpoint(20.0)
+
+        write_call = entity.hass.async_add_executor_job.call_args
+        assert write_call[0][1] == bytes.fromhex(_DAY_ENTRY["command"])
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_day_when_target_temperature_unknown(self):
+        """No live roomSetTemp reading yet -- skip the day/night probe."""
+        entity = _make_entity(night_setpoint_entry=_NIGHT_ENTRY)
+
+        entity._async_read_setpoint = AsyncMock()
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        with patch.object(
+            type(entity), "target_temperature", new_callable=PropertyMock
+        ) as mock_target_temp:
+            mock_target_temp.return_value = None
+            await entity._async_write_heat_setpoint(20.0)
+
+        entity._async_read_setpoint.assert_not_called()
+        write_call = entity.hass.async_add_executor_job.call_args
+        assert write_call[0][1] == bytes.fromhex(_DAY_ENTRY["command"])
+
+
+class TestAsyncReadSetpoint:
+    @pytest.mark.asyncio
+    async def test_decodes_value_from_device(self):
+        entity = _make_entity()
+        entity.hass.async_add_executor_job = AsyncMock(
+            return_value=bytes.fromhex("00d2")  # 210 * step(0.1) -> 21.0
+        )
+
+        result = await entity._async_read_setpoint(_DAY_ENTRY)
+
+        assert result == 21.0
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_device_error(self):
+        entity = _make_entity()
+        entity.hass.async_add_executor_job = AsyncMock(
+            side_effect=ConnectionError("device unreachable")
+        )
+
+        result = await entity._async_read_setpoint(_DAY_ENTRY)
+
+        assert result is None

--- a/tests/test_climate_manual_setpoint.py
+++ b/tests/test_climate_manual_setpoint.py
@@ -1,0 +1,175 @@
+"""Tests for THZClimate's DHW manual-mode setpoint candidate.
+
+Regression coverage for two related points:
+
+1. DHW has a distinct manual-mode setpoint register (``p11DHWsetManualTemp``)
+   in addition to day/night -- unlike HC1/HC2, whose global MANUAL MODE sets
+   a *flow* temperature (a different physical quantity entirely), not a
+   third room/water-temperature candidate. ``_async_write_heat_setpoint``'s
+   day/night/manual matching must pick up a real manual register when one is
+   wired (DHW), and never invent one for HC1/HC2 (which never pass
+   ``manual_setpoint_entry`` at all).
+
+2. With three candidates instead of two, an ambiguous read (zero matches, or
+   more than one register coincidentally reporting the same value as the
+   live target) must still fall back to the day register rather than
+   guessing.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+
+from custom_components.thz.climate import THZClimate
+
+
+_DAY_ENTRY = {"command": "0A0080", "min": "10", "max": "30", "step": "0.1"}
+_NIGHT_ENTRY = {"command": "0A0081", "min": "10", "max": "30", "step": "0.1"}
+_MANUAL_ENTRY = {"command": "0A0082", "min": "10", "max": "65", "step": "0.1"}
+
+
+def _make_dhw_entity(*, night_setpoint_entry=None, manual_setpoint_entry=None):
+    coordinator = MagicMock()
+    coordinator.data = None
+
+    device = MagicMock()
+    device.lock = asyncio.Lock()
+
+    entity = THZClimate(
+        coordinator=coordinator,
+        cooling_coordinator=None,
+        device=device,
+        device_id="test_device",
+        translation_key="DHW",
+        current_temp_offset=0,
+        current_temp_length=2,
+        target_temp_offset=2,
+        target_temp_length=2,
+        op_mode_offset=24,
+        op_mode_length=1,
+        heat_setpoint_entry=_DAY_ENTRY,
+        cool_switch_entry=None,
+        cool_setpoint_entry=None,
+        night_setpoint_entry=night_setpoint_entry,
+        manual_setpoint_entry=manual_setpoint_entry,
+    )
+    entity.hass = MagicMock()
+    entity.name = "Test DHW Entity"
+    return entity
+
+
+def _mock_read_setpoint(values: dict):
+    """Return a fake _async_read_setpoint bound to specific entry -> value pairs."""
+    async def _read(entry):
+        return values.get(id(entry))
+    return _read
+
+
+class TestManualCandidateOnlyForDhw:
+    def test_hc1_style_entity_never_gets_manual_candidate(self):
+        """HC1/HC2 setup never passes manual_setpoint_entry -- confirm the
+        entity simply has none, rather than accidentally inventing one."""
+        entity = _make_dhw_entity(night_setpoint_entry=_NIGHT_ENTRY)
+        assert entity._manual_setpoint_entry is None
+
+
+class TestThreeCandidateMatching:
+    @pytest.mark.asyncio
+    async def test_writes_manual_register_when_manual_is_active(self):
+        entity = _make_dhw_entity(
+            night_setpoint_entry=_NIGHT_ENTRY, manual_setpoint_entry=_MANUAL_ENTRY
+        )
+        values = {id(_DAY_ENTRY): 21.0, id(_NIGHT_ENTRY): 18.0, id(_MANUAL_ENTRY): 45.0}
+        entity._async_read_setpoint = _mock_read_setpoint(values)
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        with patch.object(
+            type(entity), "target_temperature", new_callable=PropertyMock
+        ) as mock_target_temp:
+            mock_target_temp.return_value = 45.0  # matches manual only
+            await entity._async_write_heat_setpoint(50.0)
+
+        write_call = entity.hass.async_add_executor_job.call_args
+        assert write_call[0][1] == bytes.fromhex(_MANUAL_ENTRY["command"])
+
+    @pytest.mark.asyncio
+    async def test_writes_day_register_when_day_is_active(self):
+        entity = _make_dhw_entity(
+            night_setpoint_entry=_NIGHT_ENTRY, manual_setpoint_entry=_MANUAL_ENTRY
+        )
+        values = {id(_DAY_ENTRY): 21.0, id(_NIGHT_ENTRY): 18.0, id(_MANUAL_ENTRY): 45.0}
+        entity._async_read_setpoint = _mock_read_setpoint(values)
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        with patch.object(
+            type(entity), "target_temperature", new_callable=PropertyMock
+        ) as mock_target_temp:
+            mock_target_temp.return_value = 21.0
+            await entity._async_write_heat_setpoint(22.0)
+
+        write_call = entity.hass.async_add_executor_job.call_args
+        assert write_call[0][1] == bytes.fromhex(_DAY_ENTRY["command"])
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_day_when_zero_matches(self):
+        """Active mode uses a register this integration doesn't know about."""
+        entity = _make_dhw_entity(
+            night_setpoint_entry=_NIGHT_ENTRY, manual_setpoint_entry=_MANUAL_ENTRY
+        )
+        values = {id(_DAY_ENTRY): 21.0, id(_NIGHT_ENTRY): 18.0, id(_MANUAL_ENTRY): 45.0}
+        entity._async_read_setpoint = _mock_read_setpoint(values)
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        with patch.object(
+            type(entity), "target_temperature", new_callable=PropertyMock
+        ) as mock_target_temp:
+            mock_target_temp.return_value = 30.0  # matches none of the three
+            await entity._async_write_heat_setpoint(31.0)
+
+        write_call = entity.hass.async_add_executor_job.call_args
+        assert write_call[0][1] == bytes.fromhex(_DAY_ENTRY["command"])
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_day_when_multiple_registers_coincide(self):
+        """Two registers happen to report the same value -- stay ambiguous,
+        don't guess."""
+        entity = _make_dhw_entity(
+            night_setpoint_entry=_NIGHT_ENTRY, manual_setpoint_entry=_MANUAL_ENTRY
+        )
+        # Night and manual coincidentally both read 21.0, same as day.
+        values = {id(_DAY_ENTRY): 21.0, id(_NIGHT_ENTRY): 21.0, id(_MANUAL_ENTRY): 45.0}
+        entity._async_read_setpoint = _mock_read_setpoint(values)
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        with patch.object(
+            type(entity), "target_temperature", new_callable=PropertyMock
+        ) as mock_target_temp:
+            mock_target_temp.return_value = 21.0
+            await entity._async_write_heat_setpoint(22.0)
+
+        write_call = entity.hass.async_add_executor_job.call_args
+        assert write_call[0][1] == bytes.fromhex(_DAY_ENTRY["command"])
+
+    @pytest.mark.asyncio
+    async def test_single_candidate_skips_matching_entirely(self):
+        """Only the day register configured -- no read probes at all,
+        exactly like before day/night support existed."""
+        entity = _make_dhw_entity()
+        entity._async_read_setpoint = AsyncMock()
+        entity.hass.async_add_executor_job = AsyncMock(return_value=None)
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        with patch.object(
+            type(entity), "target_temperature", new_callable=PropertyMock
+        ) as mock_target_temp:
+            mock_target_temp.return_value = 21.0
+            await entity._async_write_heat_setpoint(22.0)
+
+        entity._async_read_setpoint.assert_not_called()
+        write_call = entity.hass.async_add_executor_job.call_args
+        assert write_call[0][1] == bytes.fromhex(_DAY_ENTRY["command"])


### PR DESCRIPTION
HC1's global MANUAL MODE sets a flow temperature directly (MANUAL SET
HC in the operating manual), bypassing the weather-compensated curve
entirely -- a different physical quantity from the room-temperature
day/night setpoints this entity manages, not a valid candidate for
the day/night matching added previously. HC1/HC2 never get a manual
candidate at all.

DHW does have a genuine third setpoint register though
(p11DHWsetManualTemp, present on 439/539-series maps), which the
previous day/night-only matching was missing entirely.

Generalizes the day/night matching to a day/night/manual candidate
list. If exactly one candidate matches the live target reading, write
there; if zero match (active mode uses a register this integration
doesn't know about) or more than one match (values happen to
coincide), stay ambiguous and fall back to day rather than guess
wrong.

Adds tests/test_climate_manual_setpoint.py (6 tests): HC1/HC2-style
entities never get a manual candidate, writes manual when manual is
active, writes day when day is active, falls back to day on zero
matches, falls back to day when two registers coincidentally match,
and a single-candidate entity skips the read probe entirely."
git push -u origin fix/climate-manual-setpoint