### PR TITLE
Add fault log sensors for firmware 4.39/5.39

### DIFF
--- a/custom_components/thz/register_maps/readings_map_439.py
+++ b/custom_components/thz/register_maps/readings_map_439.py
@@ -195,4 +195,119 @@ REGISTER_MAP = {
             },
         ),
     ],
+    # Fault log ("sLast10errors", command D1). Despite the FHEM name, both
+    # the reference implementation and this port only decode the 4 most
+    # recent entries (fault0..fault3); the device's response evidently only
+    # carries that many. Firmware 4.39/5.39 encode fault0CODE..fault3CODE as
+    # 1 byte each (length 2 nibbles) rather than the 2 bytes (length 4
+    # nibbles) firmware 2.06 uses, and encode fault*TIME/fault*DATE with
+    # their two bytes swapped relative to 2.06's plain "hex2time"/"hexdate"
+    # (see value_codec._dec_turnhex2time / _dec_turnhexdate). Offsets below
+    # are copied verbatim from FHEM's "D1last" parsing table.
+    "pxxD1": [
+        (
+            "number_of_faults:",
+            4,
+            2,
+            "hex",
+            1,
+            {"icon": "mdi:counter", "translation_key": "number_of_faults"},
+        ),
+        (
+            " fault0CODE:",
+            8,
+            2,
+            "faultmap",
+            1,
+            {"icon": "mdi:alert-circle-outline", "translation_key": "fault0_code"},
+        ),
+        (
+            " fault0TIME:",
+            12,
+            4,
+            "turnhex2time",
+            1,
+            {"icon": "mdi:clock-outline", "translation_key": "fault0_time"},
+        ),
+        (
+            " fault0DATE:",
+            16,
+            4,
+            "turnhexdate",
+            1,
+            {"icon": "mdi:calendar", "translation_key": "fault0_date"},
+        ),
+        (
+            " fault1CODE:",
+            20,
+            2,
+            "faultmap",
+            1,
+            {"icon": "mdi:alert-circle-outline", "translation_key": "fault1_code"},
+        ),
+        (
+            " fault1TIME:",
+            24,
+            4,
+            "turnhex2time",
+            1,
+            {"icon": "mdi:clock-outline", "translation_key": "fault1_time"},
+        ),
+        (
+            " fault1DATE:",
+            28,
+            4,
+            "turnhexdate",
+            1,
+            {"icon": "mdi:calendar", "translation_key": "fault1_date"},
+        ),
+        (
+            " fault2CODE:",
+            32,
+            2,
+            "faultmap",
+            1,
+            {"icon": "mdi:alert-circle-outline", "translation_key": "fault2_code"},
+        ),
+        (
+            " fault2TIME:",
+            36,
+            4,
+            "turnhex2time",
+            1,
+            {"icon": "mdi:clock-outline", "translation_key": "fault2_time"},
+        ),
+        (
+            " fault2DATE:",
+            40,
+            4,
+            "turnhexdate",
+            1,
+            {"icon": "mdi:calendar", "translation_key": "fault2_date"},
+        ),
+        (
+            " fault3CODE:",
+            44,
+            2,
+            "faultmap",
+            1,
+            {"icon": "mdi:alert-circle-outline", "translation_key": "fault3_code"},
+        ),
+        (
+            " fault3TIME:",
+            48,
+            4,
+            "turnhex2time",
+            1,
+            {"icon": "mdi:clock-outline", "translation_key": "fault3_time"},
+        ),
+        (
+            " fault3DATE:",
+            52,
+            4,
+            "turnhexdate",
+            1,
+            {"icon": "mdi:calendar", "translation_key": "fault3_date"},
+        ),
+    ],
 }

--- a/custom_components/thz/sensor.py
+++ b/custom_components/thz/sensor.py
@@ -174,6 +174,8 @@ def decode_value(
             - "faultmap": Big-endian unsigned int looked up in faultmap table.
             - "hex2time": Big-endian decimal-encoded time → "HH:MM".
             - "hex2error": 4-byte LSB-first bitmap → comma-separated fault list.
+            - "turnhexdate"/"turnhex2time": Byte-swapped date/time, used for
+              the firmware 4.39/5.39 fault log (see value_codec for details).
             - Any other: Returns hexadecimal representation.
         factor: The divisor for "hex2int" and "hex" decoding. Defaults to 1.0.
 

--- a/custom_components/thz/value_codec.py
+++ b/custom_components/thz/value_codec.py
@@ -97,6 +97,46 @@ def _dec_hex2time(raw: bytes, factor: float) -> str:
     return f"{hours:02d}:{minutes:02d}"
 
 
+def _dec_turnhexdate(raw: bytes, factor: float) -> str:
+    """Decode a byte-swapped device date value to a "DD.MM" string.
+
+    Firmware 4.39/5.39 store the fault-log date with its two bytes in the
+    opposite order to the plain "hexdate" encoding used by firmware 2.06.
+    FHEM handles this by swapping the two hex-character pairs before doing
+    the same day/month math: ``substr($value,2,2).substr($value,0,2)`` then
+    ``sprintf("%02u.%02u", hex($value)/100, hex($value)%100)``. Reading the
+    2 raw bytes little-endian instead of big-endian produces the same swap.
+
+    Example: bytes ``0xF5 0x01`` (hex string "f501") swap to "01f5" = 501
+    decimal → day 5, month 1 → "05.01".
+    """
+    if len(raw) != 2:
+        raise ValueError(
+            f"Invalid turnhexdate length: expected 2 bytes, got {len(raw)}"
+        )
+    swapped = int.from_bytes(raw, byteorder="little")
+    return f"{swapped // 100:02d}.{swapped % 100:02d}"
+
+
+def _dec_turnhex2time(raw: bytes, factor: float) -> str:
+    """Decode a byte-swapped device time value to a "HH:MM" string.
+
+    Firmware 4.39/5.39 store the fault-log time with its two bytes in the
+    opposite order to the plain "hex2time" encoding used by firmware 2.06.
+    Matches FHEM's ``turnhex2time``: swap the two hex-character pairs, then
+    ``sprintf("%02u:%02u", hex($value)/100, hex($value)%100)``. Reading the
+    2 raw bytes little-endian instead of big-endian produces the same swap.
+    """
+    if len(raw) != 2:
+        raise ValueError(
+            f"Invalid turnhex2time length: expected 2 bytes, got {len(raw)}"
+        )
+    swapped = int.from_bytes(raw, byteorder="little")
+    hours = swapped // 100
+    minutes = swapped % 100
+    return f"{hours:02d}:{minutes:02d}"
+
+
 def _dec_hex2error(raw: bytes, factor: float) -> str:
     r"""Decode a 4-byte active-error bitmap to a comma-separated fault list.
 
@@ -137,6 +177,8 @@ _DECODE_DISPATCH: dict[str, Callable[[bytes, float], int | float | bool | str]] 
     "faultmap": _dec_faultmap,
     "hex2time": _dec_hex2time,
     "hex2error": _dec_hex2error,
+    "turnhexdate": _dec_turnhexdate,
+    "turnhex2time": _dec_turnhex2time,
 }
 
 
@@ -165,6 +207,12 @@ def decode_raw_value(
               (value/100 gives hours, value%100 gives minutes).
             - "hex2error": 4-byte LSB-first bitmap of active fault codes →
               comma-separated list of fault names, or "n.a." if none active.
+            - "turnhexdate": Byte-swapped 2-byte date → "DD.MM" (firmware
+              4.39/5.39 fault-log dates; see "hexdate" for the un-swapped
+              2.06 equivalent).
+            - "turnhex2time": Byte-swapped 2-byte time → "HH:MM" (firmware
+              4.39/5.39 fault-log times; see "hex2time" for the un-swapped
+              2.06 equivalent).
             - Any other: Returns hexadecimal representation.
         factor: The divisor for "hex2int", "hex", and "8party" decoding.
             Defaults to 1.0.

--- a/tests/test_decode_value.py
+++ b/tests/test_decode_value.py
@@ -273,6 +273,88 @@ class TestDecodeHex2Time:
         assert decode_value(raw, "hex2time") == "06:30"
 
 
+class TestDecodeTurnHex2Time:
+    """Tests for turnhex2time decoding (byte-swapped time → HH:MM string).
+
+    Firmware 4.39/5.39 fault-log times swap the two bytes relative to the
+    plain "hex2time" encoding tested above. Matches FHEM's turnhex2time:
+    swap the two hex-character pairs, then value/100 = hours, value%100 =
+    minutes. Reading the raw bytes little-endian instead of big-endian
+    performs the same swap, so each case here is the byte-reversal of the
+    equivalent TestDecodeHex2Time case.
+    """
+
+    def test_midnight(self):
+        """Test 00:00 (midnight); symmetric under swap."""
+        raw = b'\x00\x00'
+        assert decode_value(raw, "turnhex2time") == "00:00"
+
+    def test_noon(self):
+        """Test 12:00 (noon). Unswapped 1200 = 0x04B0 → swapped bytes b'\\xb0\\x04'."""
+        raw = b'\xb0\x04'
+        assert decode_value(raw, "turnhex2time") == "12:00"
+
+    def test_half_past_twelve(self):
+        """Test 12:30. Unswapped 1230 = 0x04CE → swapped bytes b'\\xce\\x04'."""
+        raw = b'\xce\x04'
+        assert decode_value(raw, "turnhex2time") == "12:30"
+
+    def test_end_of_day(self):
+        """Test 23:45. Unswapped 2345 = 0x0929 → swapped bytes b'\\x29\\x09'."""
+        raw = b'\x29\x09'
+        assert decode_value(raw, "turnhex2time") == "23:45"
+
+    def test_one_minute_past_midnight(self):
+        """Test 00:01. Unswapped 1 = 0x0001 → swapped bytes b'\\x01\\x00'."""
+        raw = b'\x01\x00'
+        assert decode_value(raw, "turnhex2time") == "00:01"
+
+    def test_single_digit_hour(self):
+        """Test 06:30 — hour must be zero-padded. Unswapped 630 = 0x0276 → swapped bytes b'\\x76\\x02'."""
+        raw = b'\x76\x02'
+        assert decode_value(raw, "turnhex2time") == "06:30"
+
+    def test_wrong_length_raises(self):
+        """Test that a non-2-byte input raises ValueError."""
+        with pytest.raises(ValueError, match="turnhex2time"):
+            decode_value(b'\x00', "turnhex2time")
+
+
+class TestDecodeTurnHexDate:
+    """Tests for turnhexdate decoding (byte-swapped date → DD.MM string).
+
+    Firmware 4.39/5.39 fault-log dates swap the two bytes relative to the
+    plain "hexdate" encoding. Matches FHEM's turnhexdate: swap the two
+    hex-character pairs, then value/100 = day, value%100 = month.
+    """
+
+    def test_zero_date(self):
+        """Test 00.00; symmetric under swap."""
+        raw = b'\x00\x00'
+        assert decode_value(raw, "turnhexdate") == "00.00"
+
+    def test_fifth_of_january(self):
+        """Test 05.01. Unswapped 501 = 0x01F5 → swapped bytes b'\\xf5\\x01'."""
+        raw = b'\xf5\x01'
+        assert decode_value(raw, "turnhexdate") == "05.01"
+
+    def test_new_years_eve(self):
+        """Test 31.12. Unswapped 3112 = 0x0C28 → swapped bytes b'\\x28\\x0c'."""
+        raw = b'\x28\x0c'
+        assert decode_value(raw, "turnhexdate") == "31.12"
+
+    def test_single_digit_day_and_month(self):
+        """Test 01.02 — both day and month must be zero-padded."""
+        # Unswapped 102 = 0x0066 → swapped bytes b'\x66\x00'
+        raw = b'\x66\x00'
+        assert decode_value(raw, "turnhexdate") == "01.02"
+
+    def test_wrong_length_raises(self):
+        """Test that a non-2-byte input raises ValueError."""
+        with pytest.raises(ValueError, match="turnhexdate"):
+            decode_value(b'\x00\x00\x00', "turnhexdate")
+
+
 class TestDecodeHex2Error:
     """Tests for hex2error decoding (4-byte LSB-first bitmap → fault list).
 

--- a/tests/test_fault_log_439.py
+++ b/tests/test_fault_log_439.py
@@ -1,0 +1,161 @@
+"""Tests for the firmware 4.39/5.39 fault log ("pxxD1") register block.
+
+Regression/feature coverage for closing a gap where this fork only ported
+FHEM's fault-log read ("D1last") for firmware 2.06 (register_map_206's
+"pxxD1" block); firmware 4.39/5.39 only had the write-side
+"zResetLast10errors" button with no matching read-back, so there was no way
+to see what a fault actually was before (or instead of) clearing it.
+
+Firmware 4.39/5.39 differ from 2.06 in two ways for this block, both taken
+verbatim from FHEM's "D1last" parsing table (as opposed to "D1last206"):
+  - fault*CODE is 1 byte (length 2 nibbles) instead of 2 bytes (length 4).
+  - fault*TIME/fault*DATE have their two bytes swapped relative to the plain
+    "hex2time"/"hexdate" decoders, requiring the "turnhex2time"/"turnhexdate"
+    decode types (see value_codec.py).
+"""
+import pytest
+
+from custom_components.thz.register_maps import readings_map_439
+from custom_components.thz.value_codec import decode_raw_value
+
+
+class TestFaultLogBlockDefinition:
+    """Structural tests for the pxxD1 block in readings_map_439.REGISTER_MAP."""
+
+    def test_pxxd1_block_exists(self):
+        """Test that the fault-log block is registered for firmware 4.39."""
+        assert "pxxD1" in readings_map_439.REGISTER_MAP
+
+    def test_pxxd1_has_thirteen_entries(self):
+        """Test entry count: number_of_faults + 4 faults * (CODE, TIME, DATE)."""
+        entries = readings_map_439.REGISTER_MAP["pxxD1"]
+        assert len(entries) == 13
+
+    def test_number_of_faults_entry(self):
+        """Test the number_of_faults entry matches FHEM's D1last offset/type."""
+        entries = readings_map_439.REGISTER_MAP["pxxD1"]
+        name, offset, length, decode, factor = entries[0][:5]
+        assert name.strip().rstrip(":") == "number_of_faults"
+        assert (offset, length, decode) == (4, 2, "hex")
+
+    @pytest.mark.parametrize(
+        "index,fault_num,code_offset,time_offset,date_offset",
+        [
+            (1, 0, 8, 12, 16),
+            (4, 1, 20, 24, 28),
+            (7, 2, 32, 36, 40),
+            (10, 3, 44, 48, 52),
+        ],
+    )
+    def test_fault_offsets_match_fhem_d1last(
+        self, index, fault_num, code_offset, time_offset, date_offset
+    ):
+        """Offsets/lengths/decode-types must match FHEM's D1last table verbatim."""
+        entries = readings_map_439.REGISTER_MAP["pxxD1"]
+        code_name, code_off, code_len, code_decode, _ = entries[index][:5]
+        time_name, time_off, time_len, time_decode, _ = entries[index + 1][:5]
+        date_name, date_off, date_len, date_decode, _ = entries[index + 2][:5]
+
+        assert code_name.strip().rstrip(":") == f"fault{fault_num}CODE"
+        assert (code_off, code_len, code_decode) == (code_offset, 2, "faultmap")
+
+        assert time_name.strip().rstrip(":") == f"fault{fault_num}TIME"
+        assert (time_off, time_len, time_decode) == (
+            time_offset,
+            4,
+            "turnhex2time",
+        )
+
+        assert date_name.strip().rstrip(":") == f"fault{fault_num}DATE"
+        assert (date_off, date_len, date_decode) == (date_offset, 4, "turnhexdate")
+
+
+class TestFaultLogEndToEndDecode:
+    """End-to-end decode of a synthetic pxxD1 device response.
+
+    Mirrors the nibble-offset -> byte-offset conversion sensor.py applies
+    (offset // 2, (length + 1) // 2) so this test would catch a regression
+    in either the register map offsets or the decode functions, not just
+    one in isolation.
+    """
+
+    @staticmethod
+    def _extract(message_hex: str, offset_nibbles: int, length_nibbles: int, decode_type: str):
+        byte_offset = offset_nibbles // 2
+        byte_length = (length_nibbles + 1) // 2
+        raw = bytes.fromhex(message_hex)[byte_offset : byte_offset + byte_length]
+        return decode_raw_value(raw, decode_type, 1)
+
+    def _decode_block(self, message: bytes) -> dict:
+        message_hex = message.hex()
+        entries = readings_map_439.REGISTER_MAP["pxxD1"]
+        results = {}
+        for entry in entries:
+            name, offset, length, decode, factor = entry[:5]
+            results[name.strip().rstrip(":")] = self._extract(
+                message_hex, offset, length, decode
+            )
+        return results
+
+    def test_single_active_fault(self):
+        """One active fault (fault0), the other three slots all-zero/n.a."""
+        raw = bytearray(28)
+        raw[2] = 0x01  # number_of_faults = 1
+        raw[4] = 0x03  # fault0CODE = 3 -> F03_HighPreasureGuardFault
+        raw[6], raw[7] = 0xCE, 0x04  # fault0TIME swapped -> 12:30
+        raw[8], raw[9] = 0xF5, 0x01  # fault0DATE swapped -> 05.01
+        # bytes 10-27 (fault1..fault3) stay zero -> n.a. / 00:00 / 00.00
+
+        results = self._decode_block(bytes(raw))
+
+        assert results["number_of_faults"] == 1
+        assert results["fault0CODE"] == "F03_HighPreasureGuardFault"
+        assert results["fault0TIME"] == "12:30"
+        assert results["fault0DATE"] == "05.01"
+        assert results["fault1CODE"] == "n.a."
+        assert results["fault1TIME"] == "00:00"
+        assert results["fault1DATE"] == "00.00"
+
+    def test_all_faults_populated(self):
+        """All four fault slots populated with distinct code/time/date values."""
+        raw = bytearray(28)
+        raw[2] = 0x04  # number_of_faults = 4
+
+        raw[4] = 0x01  # fault0CODE -> F01_AnodeFault
+        raw[6], raw[7] = 0xB0, 0x04  # fault0TIME swapped -> 12:00
+        raw[8], raw[9] = 0x28, 0x0C  # fault0DATE swapped -> 31.12
+
+        raw[10] = 0x02  # fault1CODE -> F02_SafetyTempDelimiterEngaged
+        raw[12], raw[13] = 0x29, 0x09  # fault1TIME swapped -> 23:45
+        raw[14], raw[15] = 0x66, 0x00  # fault1DATE swapped -> 01.02
+
+        raw[16] = 0x24  # fault2CODE (36) -> F36_MinFlowRate
+        raw[18], raw[19] = 0x01, 0x00  # fault2TIME swapped -> 00:01
+        raw[20], raw[21] = 0xF5, 0x01  # fault2DATE swapped -> 05.01
+
+        raw[22] = 0x34  # fault3CODE (52) -> F52_SensorCondenserOutlet
+        raw[24], raw[25] = 0x76, 0x02  # fault3TIME swapped -> 06:30
+        raw[26], raw[27] = 0x00, 0x00  # fault3DATE -> 00.00
+
+        results = self._decode_block(bytes(raw))
+
+        assert results["number_of_faults"] == 4
+        assert results["fault0CODE"] == "F01_AnodeFault"
+        assert results["fault0TIME"] == "12:00"
+        assert results["fault0DATE"] == "31.12"
+        assert results["fault1CODE"] == "F02_SafetyTempDelimiterEngaged"
+        assert results["fault1TIME"] == "23:45"
+        assert results["fault1DATE"] == "01.02"
+        assert results["fault2CODE"] == "F36_MinFlowRate"
+        assert results["fault2TIME"] == "00:01"
+        assert results["fault2DATE"] == "05.01"
+        assert results["fault3CODE"] == "F52_SensorCondenserOutlet"
+        assert results["fault3TIME"] == "06:30"
+        assert results["fault3DATE"] == "00.00"
+
+    def test_no_faults(self):
+        """An all-zero response decodes as zero faults, no crash."""
+        raw = bytes(28)
+        results = self._decode_block(raw)
+        assert results["number_of_faults"] == 0
+        assert results["fault0CODE"] == "n.a."


### PR DESCRIPTION
Firmware 4.39/5.39 expose a fault-log block (pxxD1) with the four most recent faults, each as a code/date/time triple. The date/time fields use a byte-swapped variant of the existing hexdate/hex2time encoding (the two bytes are in the opposite order from firmware 2.06), so this adds two new decode types -- turnhexdate and turnhex2time -- alongside the existing ones, plus the register-map block that uses them.

Purely additive: no existing decode types, register entries, or behavior change.