### PR TITLE
Feature/solar fan status 439

### DIFF
--- a/custom_components/thz/const.py
+++ b/custom_components/thz/const.py
@@ -71,8 +71,9 @@ BLOCK_LABELS: dict[str, str] = {
     "pxx0E":      "Setback Settings",
     "pxx0F":      "Absence Program",
     "pxx10":      "Dry Heat Settings",
+    "pxx16":      "Solar Circuit",
     "pxx17":      "Setpoint Temperatures",
-    "pxxE8":      "Air Flow Calibration",
+    "pxxE8":      "Fan Status & Air Flow",
     "pxxEE":      "Operating Mode & Programs",
     "pxxF6":      "Fan Stage & Error Log",
     # Firmware 4.39 energy sensors

--- a/custom_components/thz/register_maps/readings_map_439.py
+++ b/custom_components/thz/register_maps/readings_map_439.py
@@ -28,6 +28,12 @@ _ENERGY_TOTAL = {
     "state_class": "total_increasing",
 }
 _RUNTIME = {"unit": "h", "device_class": "duration", "state_class": "total_increasing", "icon": "mdi:timer-outline"}
+_TEMP = {
+    "unit": "°C",
+    "device_class": "temperature",
+    "state_class": "measurement",
+    "icon": "mdi:thermometer",
+}
 
 # Paired register blocks: maps cmd2 block key to cmd3 block key.
 # The coordinator reads both registers and combines them:
@@ -308,6 +314,140 @@ REGISTER_MAP = {
             "turnhexdate",
             1,
             {"icon": "mdi:calendar", "translation_key": "fault3_date"},
+        ),
+    ],
+    # NOTE: live pump-running status (dhwPump/heatingCircuitPump/solarPump,
+    # "sGlobal" command FB, bits 0/1/3) is NOT defined here. It was briefly
+    # added in this spot and then removed again: register_map_all.py (the
+    # universal base map merged in for every firmware family, see
+    # RegisterMapManager's base_map_name="register_map_all") already defines
+    # an identical "pxxFB" block at the same offsets, so 4.39/5.39 already had
+    # this data available -- adding it again here was pure duplication with
+    # nothing behind it. See CHANGELOG.md's "Correction" entry.
+    #
+    # Solar circuit readings ("sSol", command 16). Distinct from p80EnableSolar
+    # (the on/off master switch, already implemented) and from the solar_pump
+    # running-status bit (already implemented, part of the base pxxFB block) --
+    # this is the solar-circuit-specific temperature/runtime data FHEM exposes
+    # under its own command, and it was entirely unported for this firmware
+    # family. Offsets copied verbatim from FHEM's "16sol" parsing table;
+    # nibbles 18-25 are an unused gap in FHEM's own table, not an omission
+    # here. "out"/"status" use decode_type "raw" (falls through to a plain
+    # hex-string representation -- same as the existing "out"/dhw_out_mode
+    # entry in pxxF3) since FHEM never documents what they decode to.
+    "pxx16": [
+        (
+            "collectorTemp:",
+            4,
+            4,
+            "hex2int",
+            10,
+            {**_TEMP, "icon": "mdi:solar-power", "translation_key": "solar_collector_temp"},
+        ),
+        (
+            " dhwTemp:",
+            8,
+            4,
+            "hex2int",
+            10,
+            {**_TEMP, "icon": "mdi:water-boiler", "translation_key": "solar_dhw_temp"},
+        ),
+        (
+            " flowTemp:",
+            12,
+            4,
+            "hex2int",
+            10,
+            {**_TEMP, "translation_key": "solar_flow_temp"},
+        ),
+        (
+            " edSolPump:",
+            16,
+            2,
+            "hex2int",
+            1,
+            {"icon": "mdi:pump", "translation_key": "solar_pump_hours"},
+        ),
+        (
+            " out:",
+            26,
+            4,
+            "raw",
+            1,
+            {"translation_key": "solar_out"},
+        ),
+        (
+            " status:",
+            30,
+            2,
+            "raw",
+            1,
+            {"translation_key": "solar_status"},
+        ),
+    ],
+    # Ventilation/fan readings ("sFan", command E8). Distinct from the
+    # p07/p08/p09/p12/p43-46/p99 fan-stage *settings* (already implemented as
+    # write entities) -- this is the live fan speed/airflow/power data FHEM
+    # exposes under its own command, entirely unported for this firmware
+    # family. Note this is a DIFFERENT byte layout from register_map_206.py's
+    # own pxxE8 block ("E8fan206" in FHEM), which does not apply to 4.39/5.39.
+    # Offsets copied verbatim from FHEM's "E8fan" parsing table.
+    "pxxE8": [
+        (
+            "inputFanSpeed:",
+            58,
+            2,
+            "hex",
+            1,
+            {"icon": "mdi:fan", "translation_key": "input_fan_speed"},
+        ),
+        (
+            " outputFanSpeed:",
+            60,
+            2,
+            "hex",
+            1,
+            {"icon": "mdi:fan", "translation_key": "output_fan_speed"},
+        ),
+        (
+            " pFanstageXAirflowInlet:",
+            62,
+            4,
+            "hex",
+            1,
+            {
+                "unit": "m³/h",
+                "icon": "mdi:air-filter",
+                "translation_key": "fan_stage_airflow_inlet",
+            },
+        ),
+        (
+            " pFanstageXAirflowOutlet:",
+            66,
+            4,
+            "hex",
+            1,
+            {
+                "unit": "m³/h",
+                "icon": "mdi:air-filter",
+                "translation_key": "fan_stage_airflow_outlet",
+            },
+        ),
+        (
+            " inputFanPower:",
+            70,
+            2,
+            "hex",
+            1,
+            {"unit": "%", "icon": "mdi:fan", "translation_key": "input_fan_power"},
+        ),
+        (
+            " outputFanPower:",
+            72,
+            2,
+            "hex",
+            1,
+            {"unit": "%", "icon": "mdi:fan", "translation_key": "output_fan_power"},
         ),
     ],
 }

--- a/custom_components/thz/register_maps/readings_map_439.py
+++ b/custom_components/thz/register_maps/readings_map_439.py
@@ -195,4 +195,119 @@ REGISTER_MAP = {
             },
         ),
     ],
+    # Fault log ("sLast10errors", command D1). Despite the FHEM name, both
+    # the reference implementation and this port only decode the 4 most
+    # recent entries (fault0..fault3); the device's response evidently only
+    # carries that many. Firmware 4.39/5.39 encode fault0CODE..fault3CODE as
+    # 1 byte each (length 2 nibbles) rather than the 2 bytes (length 4
+    # nibbles) firmware 2.06 uses, and encode fault*TIME/fault*DATE with
+    # their two bytes swapped relative to 2.06's plain "hex2time"/"hexdate"
+    # (see value_codec._dec_turnhex2time / _dec_turnhexdate). Offsets below
+    # are copied verbatim from FHEM's "D1last" parsing table.
+    "pxxD1": [
+        (
+            "number_of_faults:",
+            4,
+            2,
+            "hex",
+            1,
+            {"icon": "mdi:counter", "translation_key": "number_of_faults"},
+        ),
+        (
+            " fault0CODE:",
+            8,
+            2,
+            "faultmap",
+            1,
+            {"icon": "mdi:alert-circle-outline", "translation_key": "fault0_code"},
+        ),
+        (
+            " fault0TIME:",
+            12,
+            4,
+            "turnhex2time",
+            1,
+            {"icon": "mdi:clock-outline", "translation_key": "fault0_time"},
+        ),
+        (
+            " fault0DATE:",
+            16,
+            4,
+            "turnhexdate",
+            1,
+            {"icon": "mdi:calendar", "translation_key": "fault0_date"},
+        ),
+        (
+            " fault1CODE:",
+            20,
+            2,
+            "faultmap",
+            1,
+            {"icon": "mdi:alert-circle-outline", "translation_key": "fault1_code"},
+        ),
+        (
+            " fault1TIME:",
+            24,
+            4,
+            "turnhex2time",
+            1,
+            {"icon": "mdi:clock-outline", "translation_key": "fault1_time"},
+        ),
+        (
+            " fault1DATE:",
+            28,
+            4,
+            "turnhexdate",
+            1,
+            {"icon": "mdi:calendar", "translation_key": "fault1_date"},
+        ),
+        (
+            " fault2CODE:",
+            32,
+            2,
+            "faultmap",
+            1,
+            {"icon": "mdi:alert-circle-outline", "translation_key": "fault2_code"},
+        ),
+        (
+            " fault2TIME:",
+            36,
+            4,
+            "turnhex2time",
+            1,
+            {"icon": "mdi:clock-outline", "translation_key": "fault2_time"},
+        ),
+        (
+            " fault2DATE:",
+            40,
+            4,
+            "turnhexdate",
+            1,
+            {"icon": "mdi:calendar", "translation_key": "fault2_date"},
+        ),
+        (
+            " fault3CODE:",
+            44,
+            2,
+            "faultmap",
+            1,
+            {"icon": "mdi:alert-circle-outline", "translation_key": "fault3_code"},
+        ),
+        (
+            " fault3TIME:",
+            48,
+            4,
+            "turnhex2time",
+            1,
+            {"icon": "mdi:clock-outline", "translation_key": "fault3_time"},
+        ),
+        (
+            " fault3DATE:",
+            52,
+            4,
+            "turnhexdate",
+            1,
+            {"icon": "mdi:calendar", "translation_key": "fault3_date"},
+        ),
+    ],
 }

--- a/custom_components/thz/sensor.py
+++ b/custom_components/thz/sensor.py
@@ -174,6 +174,8 @@ def decode_value(
             - "faultmap": Big-endian unsigned int looked up in faultmap table.
             - "hex2time": Big-endian decimal-encoded time → "HH:MM".
             - "hex2error": 4-byte LSB-first bitmap → comma-separated fault list.
+            - "turnhexdate"/"turnhex2time": Byte-swapped date/time, used for
+              the firmware 4.39/5.39 fault log (see value_codec for details).
             - Any other: Returns hexadecimal representation.
         factor: The divisor for "hex2int" and "hex" decoding. Defaults to 1.0.
 

--- a/custom_components/thz/strings.json
+++ b/custom_components/thz/strings.json
@@ -344,6 +344,42 @@
       "collector_temp": {
         "name": "Collector Temperature"
       },
+      "solar_collector_temp": {
+        "name": "Solar Collector Temperature"
+      },
+      "solar_dhw_temp": {
+        "name": "Solar DHW Temperature"
+      },
+      "solar_flow_temp": {
+        "name": "Solar Flow Temperature"
+      },
+      "solar_pump_hours": {
+        "name": "Solar Pump Runtime Hours"
+      },
+      "solar_out": {
+        "name": "Solar Output"
+      },
+      "solar_status": {
+        "name": "Solar Status"
+      },
+      "input_fan_speed": {
+        "name": "Input Fan Speed"
+      },
+      "output_fan_speed": {
+        "name": "Output Fan Speed"
+      },
+      "fan_stage_airflow_inlet": {
+        "name": "Fan Stage Airflow Inlet"
+      },
+      "fan_stage_airflow_outlet": {
+        "name": "Fan Stage Airflow Outlet"
+      },
+      "input_fan_power": {
+        "name": "Input Fan Power"
+      },
+      "output_fan_power": {
+        "name": "Output Fan Power"
+      },
       "inside_temp": {
         "name": "Inside Temperature"
       },

--- a/custom_components/thz/translations/en.json
+++ b/custom_components/thz/translations/en.json
@@ -351,6 +351,42 @@
       "collector_temp": {
         "name": "Collector Temperature"
       },
+      "solar_collector_temp": {
+        "name": "Solar Collector Temperature"
+      },
+      "solar_dhw_temp": {
+        "name": "Solar DHW Temperature"
+      },
+      "solar_flow_temp": {
+        "name": "Solar Flow Temperature"
+      },
+      "solar_pump_hours": {
+        "name": "Solar Pump Runtime Hours"
+      },
+      "solar_out": {
+        "name": "Solar Output"
+      },
+      "solar_status": {
+        "name": "Solar Status"
+      },
+      "input_fan_speed": {
+        "name": "Input Fan Speed"
+      },
+      "output_fan_speed": {
+        "name": "Output Fan Speed"
+      },
+      "fan_stage_airflow_inlet": {
+        "name": "Fan Stage Airflow Inlet"
+      },
+      "fan_stage_airflow_outlet": {
+        "name": "Fan Stage Airflow Outlet"
+      },
+      "input_fan_power": {
+        "name": "Input Fan Power"
+      },
+      "output_fan_power": {
+        "name": "Output Fan Power"
+      },
       "inside_temp": {
         "name": "Inside Temperature"
       },

--- a/custom_components/thz/value_codec.py
+++ b/custom_components/thz/value_codec.py
@@ -97,6 +97,46 @@ def _dec_hex2time(raw: bytes, factor: float) -> str:
     return f"{hours:02d}:{minutes:02d}"
 
 
+def _dec_turnhexdate(raw: bytes, factor: float) -> str:
+    """Decode a byte-swapped device date value to a "DD.MM" string.
+
+    Firmware 4.39/5.39 store the fault-log date with its two bytes in the
+    opposite order to the plain "hexdate" encoding used by firmware 2.06.
+    FHEM handles this by swapping the two hex-character pairs before doing
+    the same day/month math: ``substr($value,2,2).substr($value,0,2)`` then
+    ``sprintf("%02u.%02u", hex($value)/100, hex($value)%100)``. Reading the
+    2 raw bytes little-endian instead of big-endian produces the same swap.
+
+    Example: bytes ``0xF5 0x01`` (hex string "f501") swap to "01f5" = 501
+    decimal → day 5, month 1 → "05.01".
+    """
+    if len(raw) != 2:
+        raise ValueError(
+            f"Invalid turnhexdate length: expected 2 bytes, got {len(raw)}"
+        )
+    swapped = int.from_bytes(raw, byteorder="little")
+    return f"{swapped // 100:02d}.{swapped % 100:02d}"
+
+
+def _dec_turnhex2time(raw: bytes, factor: float) -> str:
+    """Decode a byte-swapped device time value to a "HH:MM" string.
+
+    Firmware 4.39/5.39 store the fault-log time with its two bytes in the
+    opposite order to the plain "hex2time" encoding used by firmware 2.06.
+    Matches FHEM's ``turnhex2time``: swap the two hex-character pairs, then
+    ``sprintf("%02u:%02u", hex($value)/100, hex($value)%100)``. Reading the
+    2 raw bytes little-endian instead of big-endian produces the same swap.
+    """
+    if len(raw) != 2:
+        raise ValueError(
+            f"Invalid turnhex2time length: expected 2 bytes, got {len(raw)}"
+        )
+    swapped = int.from_bytes(raw, byteorder="little")
+    hours = swapped // 100
+    minutes = swapped % 100
+    return f"{hours:02d}:{minutes:02d}"
+
+
 def _dec_hex2error(raw: bytes, factor: float) -> str:
     r"""Decode a 4-byte active-error bitmap to a comma-separated fault list.
 
@@ -137,6 +177,8 @@ _DECODE_DISPATCH: dict[str, Callable[[bytes, float], int | float | bool | str]] 
     "faultmap": _dec_faultmap,
     "hex2time": _dec_hex2time,
     "hex2error": _dec_hex2error,
+    "turnhexdate": _dec_turnhexdate,
+    "turnhex2time": _dec_turnhex2time,
 }
 
 
@@ -165,6 +207,12 @@ def decode_raw_value(
               (value/100 gives hours, value%100 gives minutes).
             - "hex2error": 4-byte LSB-first bitmap of active fault codes →
               comma-separated list of fault names, or "n.a." if none active.
+            - "turnhexdate": Byte-swapped 2-byte date → "DD.MM" (firmware
+              4.39/5.39 fault-log dates; see "hexdate" for the un-swapped
+              2.06 equivalent).
+            - "turnhex2time": Byte-swapped 2-byte time → "HH:MM" (firmware
+              4.39/5.39 fault-log times; see "hex2time" for the un-swapped
+              2.06 equivalent).
             - Any other: Returns hexadecimal representation.
         factor: The divisor for "hex2int", "hex", and "8party" decoding.
             Defaults to 1.0.

--- a/tests/test_decode_value.py
+++ b/tests/test_decode_value.py
@@ -273,6 +273,88 @@ class TestDecodeHex2Time:
         assert decode_value(raw, "hex2time") == "06:30"
 
 
+class TestDecodeTurnHex2Time:
+    """Tests for turnhex2time decoding (byte-swapped time → HH:MM string).
+
+    Firmware 4.39/5.39 fault-log times swap the two bytes relative to the
+    plain "hex2time" encoding tested above. Matches FHEM's turnhex2time:
+    swap the two hex-character pairs, then value/100 = hours, value%100 =
+    minutes. Reading the raw bytes little-endian instead of big-endian
+    performs the same swap, so each case here is the byte-reversal of the
+    equivalent TestDecodeHex2Time case.
+    """
+
+    def test_midnight(self):
+        """Test 00:00 (midnight); symmetric under swap."""
+        raw = b'\x00\x00'
+        assert decode_value(raw, "turnhex2time") == "00:00"
+
+    def test_noon(self):
+        """Test 12:00 (noon). Unswapped 1200 = 0x04B0 → swapped bytes b'\\xb0\\x04'."""
+        raw = b'\xb0\x04'
+        assert decode_value(raw, "turnhex2time") == "12:00"
+
+    def test_half_past_twelve(self):
+        """Test 12:30. Unswapped 1230 = 0x04CE → swapped bytes b'\\xce\\x04'."""
+        raw = b'\xce\x04'
+        assert decode_value(raw, "turnhex2time") == "12:30"
+
+    def test_end_of_day(self):
+        """Test 23:45. Unswapped 2345 = 0x0929 → swapped bytes b'\\x29\\x09'."""
+        raw = b'\x29\x09'
+        assert decode_value(raw, "turnhex2time") == "23:45"
+
+    def test_one_minute_past_midnight(self):
+        """Test 00:01. Unswapped 1 = 0x0001 → swapped bytes b'\\x01\\x00'."""
+        raw = b'\x01\x00'
+        assert decode_value(raw, "turnhex2time") == "00:01"
+
+    def test_single_digit_hour(self):
+        """Test 06:30 — hour must be zero-padded. Unswapped 630 = 0x0276 → swapped bytes b'\\x76\\x02'."""
+        raw = b'\x76\x02'
+        assert decode_value(raw, "turnhex2time") == "06:30"
+
+    def test_wrong_length_raises(self):
+        """Test that a non-2-byte input raises ValueError."""
+        with pytest.raises(ValueError, match="turnhex2time"):
+            decode_value(b'\x00', "turnhex2time")
+
+
+class TestDecodeTurnHexDate:
+    """Tests for turnhexdate decoding (byte-swapped date → DD.MM string).
+
+    Firmware 4.39/5.39 fault-log dates swap the two bytes relative to the
+    plain "hexdate" encoding. Matches FHEM's turnhexdate: swap the two
+    hex-character pairs, then value/100 = day, value%100 = month.
+    """
+
+    def test_zero_date(self):
+        """Test 00.00; symmetric under swap."""
+        raw = b'\x00\x00'
+        assert decode_value(raw, "turnhexdate") == "00.00"
+
+    def test_fifth_of_january(self):
+        """Test 05.01. Unswapped 501 = 0x01F5 → swapped bytes b'\\xf5\\x01'."""
+        raw = b'\xf5\x01'
+        assert decode_value(raw, "turnhexdate") == "05.01"
+
+    def test_new_years_eve(self):
+        """Test 31.12. Unswapped 3112 = 0x0C28 → swapped bytes b'\\x28\\x0c'."""
+        raw = b'\x28\x0c'
+        assert decode_value(raw, "turnhexdate") == "31.12"
+
+    def test_single_digit_day_and_month(self):
+        """Test 01.02 — both day and month must be zero-padded."""
+        # Unswapped 102 = 0x0066 → swapped bytes b'\x66\x00'
+        raw = b'\x66\x00'
+        assert decode_value(raw, "turnhexdate") == "01.02"
+
+    def test_wrong_length_raises(self):
+        """Test that a non-2-byte input raises ValueError."""
+        with pytest.raises(ValueError, match="turnhexdate"):
+            decode_value(b'\x00\x00\x00', "turnhexdate")
+
+
 class TestDecodeHex2Error:
     """Tests for hex2error decoding (4-byte LSB-first bitmap → fault list).
 

--- a/tests/test_fault_log_439.py
+++ b/tests/test_fault_log_439.py
@@ -1,0 +1,161 @@
+"""Tests for the firmware 4.39/5.39 fault log ("pxxD1") register block.
+
+Regression/feature coverage for closing a gap where this fork only ported
+FHEM's fault-log read ("D1last") for firmware 2.06 (register_map_206's
+"pxxD1" block); firmware 4.39/5.39 only had the write-side
+"zResetLast10errors" button with no matching read-back, so there was no way
+to see what a fault actually was before (or instead of) clearing it.
+
+Firmware 4.39/5.39 differ from 2.06 in two ways for this block, both taken
+verbatim from FHEM's "D1last" parsing table (as opposed to "D1last206"):
+  - fault*CODE is 1 byte (length 2 nibbles) instead of 2 bytes (length 4).
+  - fault*TIME/fault*DATE have their two bytes swapped relative to the plain
+    "hex2time"/"hexdate" decoders, requiring the "turnhex2time"/"turnhexdate"
+    decode types (see value_codec.py).
+"""
+import pytest
+
+from custom_components.thz.register_maps import readings_map_439
+from custom_components.thz.value_codec import decode_raw_value
+
+
+class TestFaultLogBlockDefinition:
+    """Structural tests for the pxxD1 block in readings_map_439.REGISTER_MAP."""
+
+    def test_pxxd1_block_exists(self):
+        """Test that the fault-log block is registered for firmware 4.39."""
+        assert "pxxD1" in readings_map_439.REGISTER_MAP
+
+    def test_pxxd1_has_thirteen_entries(self):
+        """Test entry count: number_of_faults + 4 faults * (CODE, TIME, DATE)."""
+        entries = readings_map_439.REGISTER_MAP["pxxD1"]
+        assert len(entries) == 13
+
+    def test_number_of_faults_entry(self):
+        """Test the number_of_faults entry matches FHEM's D1last offset/type."""
+        entries = readings_map_439.REGISTER_MAP["pxxD1"]
+        name, offset, length, decode, factor = entries[0][:5]
+        assert name.strip().rstrip(":") == "number_of_faults"
+        assert (offset, length, decode) == (4, 2, "hex")
+
+    @pytest.mark.parametrize(
+        "index,fault_num,code_offset,time_offset,date_offset",
+        [
+            (1, 0, 8, 12, 16),
+            (4, 1, 20, 24, 28),
+            (7, 2, 32, 36, 40),
+            (10, 3, 44, 48, 52),
+        ],
+    )
+    def test_fault_offsets_match_fhem_d1last(
+        self, index, fault_num, code_offset, time_offset, date_offset
+    ):
+        """Offsets/lengths/decode-types must match FHEM's D1last table verbatim."""
+        entries = readings_map_439.REGISTER_MAP["pxxD1"]
+        code_name, code_off, code_len, code_decode, _ = entries[index][:5]
+        time_name, time_off, time_len, time_decode, _ = entries[index + 1][:5]
+        date_name, date_off, date_len, date_decode, _ = entries[index + 2][:5]
+
+        assert code_name.strip().rstrip(":") == f"fault{fault_num}CODE"
+        assert (code_off, code_len, code_decode) == (code_offset, 2, "faultmap")
+
+        assert time_name.strip().rstrip(":") == f"fault{fault_num}TIME"
+        assert (time_off, time_len, time_decode) == (
+            time_offset,
+            4,
+            "turnhex2time",
+        )
+
+        assert date_name.strip().rstrip(":") == f"fault{fault_num}DATE"
+        assert (date_off, date_len, date_decode) == (date_offset, 4, "turnhexdate")
+
+
+class TestFaultLogEndToEndDecode:
+    """End-to-end decode of a synthetic pxxD1 device response.
+
+    Mirrors the nibble-offset -> byte-offset conversion sensor.py applies
+    (offset // 2, (length + 1) // 2) so this test would catch a regression
+    in either the register map offsets or the decode functions, not just
+    one in isolation.
+    """
+
+    @staticmethod
+    def _extract(message_hex: str, offset_nibbles: int, length_nibbles: int, decode_type: str):
+        byte_offset = offset_nibbles // 2
+        byte_length = (length_nibbles + 1) // 2
+        raw = bytes.fromhex(message_hex)[byte_offset : byte_offset + byte_length]
+        return decode_raw_value(raw, decode_type, 1)
+
+    def _decode_block(self, message: bytes) -> dict:
+        message_hex = message.hex()
+        entries = readings_map_439.REGISTER_MAP["pxxD1"]
+        results = {}
+        for entry in entries:
+            name, offset, length, decode, factor = entry[:5]
+            results[name.strip().rstrip(":")] = self._extract(
+                message_hex, offset, length, decode
+            )
+        return results
+
+    def test_single_active_fault(self):
+        """One active fault (fault0), the other three slots all-zero/n.a."""
+        raw = bytearray(28)
+        raw[2] = 0x01  # number_of_faults = 1
+        raw[4] = 0x03  # fault0CODE = 3 -> F03_HighPreasureGuardFault
+        raw[6], raw[7] = 0xCE, 0x04  # fault0TIME swapped -> 12:30
+        raw[8], raw[9] = 0xF5, 0x01  # fault0DATE swapped -> 05.01
+        # bytes 10-27 (fault1..fault3) stay zero -> n.a. / 00:00 / 00.00
+
+        results = self._decode_block(bytes(raw))
+
+        assert results["number_of_faults"] == 1
+        assert results["fault0CODE"] == "F03_HighPreasureGuardFault"
+        assert results["fault0TIME"] == "12:30"
+        assert results["fault0DATE"] == "05.01"
+        assert results["fault1CODE"] == "n.a."
+        assert results["fault1TIME"] == "00:00"
+        assert results["fault1DATE"] == "00.00"
+
+    def test_all_faults_populated(self):
+        """All four fault slots populated with distinct code/time/date values."""
+        raw = bytearray(28)
+        raw[2] = 0x04  # number_of_faults = 4
+
+        raw[4] = 0x01  # fault0CODE -> F01_AnodeFault
+        raw[6], raw[7] = 0xB0, 0x04  # fault0TIME swapped -> 12:00
+        raw[8], raw[9] = 0x28, 0x0C  # fault0DATE swapped -> 31.12
+
+        raw[10] = 0x02  # fault1CODE -> F02_SafetyTempDelimiterEngaged
+        raw[12], raw[13] = 0x29, 0x09  # fault1TIME swapped -> 23:45
+        raw[14], raw[15] = 0x66, 0x00  # fault1DATE swapped -> 01.02
+
+        raw[16] = 0x24  # fault2CODE (36) -> F36_MinFlowRate
+        raw[18], raw[19] = 0x01, 0x00  # fault2TIME swapped -> 00:01
+        raw[20], raw[21] = 0xF5, 0x01  # fault2DATE swapped -> 05.01
+
+        raw[22] = 0x34  # fault3CODE (52) -> F52_SensorCondenserOutlet
+        raw[24], raw[25] = 0x76, 0x02  # fault3TIME swapped -> 06:30
+        raw[26], raw[27] = 0x00, 0x00  # fault3DATE -> 00.00
+
+        results = self._decode_block(bytes(raw))
+
+        assert results["number_of_faults"] == 4
+        assert results["fault0CODE"] == "F01_AnodeFault"
+        assert results["fault0TIME"] == "12:00"
+        assert results["fault0DATE"] == "31.12"
+        assert results["fault1CODE"] == "F02_SafetyTempDelimiterEngaged"
+        assert results["fault1TIME"] == "23:45"
+        assert results["fault1DATE"] == "01.02"
+        assert results["fault2CODE"] == "F36_MinFlowRate"
+        assert results["fault2TIME"] == "00:01"
+        assert results["fault2DATE"] == "05.01"
+        assert results["fault3CODE"] == "F52_SensorCondenserOutlet"
+        assert results["fault3TIME"] == "06:30"
+        assert results["fault3DATE"] == "00.00"
+
+    def test_no_faults(self):
+        """An all-zero response decodes as zero faults, no crash."""
+        raw = bytes(28)
+        results = self._decode_block(raw)
+        assert results["number_of_faults"] == 0
+        assert results["fault0CODE"] == "n.a."

--- a/tests/test_solar_and_fan_439.py
+++ b/tests/test_solar_and_fan_439.py
@@ -1,0 +1,156 @@
+"""Tests for the solar circuit ("pxx16") and fan status ("pxxE8") blocks
+added for firmware 4.39/5.39.
+
+These were entirely unported gaps found via a systematic audit against
+FHEM's 00_THZ.pm: firmware 4.39/5.39 (and everything read via the shared
+readings_map_439 base) had no equivalent of FHEM's "sSol" (command 16,
+solar-circuit temperatures/runtime) or "sFan" (command E8, live fan
+speed/airflow/power) at all, distinct from the already-implemented
+p80EnableSolar (on/off switch), solar_pump (running-status bit), and the
+p07/08/09/12/43-46/99 fan-stage *setting* write entities.
+"""
+import pytest
+
+from custom_components.thz.register_maps import readings_map_439
+from custom_components.thz.value_codec import decode_raw_value
+
+
+class TestSolarBlockDefinition:
+    """Structural tests for the pxx16 (sSol) block."""
+
+    def test_pxx16_block_exists(self):
+        assert "pxx16" in readings_map_439.REGISTER_MAP
+
+    def test_pxx16_has_six_entries(self):
+        entries = readings_map_439.REGISTER_MAP["pxx16"]
+        assert len(entries) == 6
+
+    @pytest.mark.parametrize(
+        "index,name,offset,length,decode,factor",
+        [
+            (0, "collectorTemp", 4, 4, "hex2int", 10),
+            (1, "dhwTemp", 8, 4, "hex2int", 10),
+            (2, "flowTemp", 12, 4, "hex2int", 10),
+            (3, "edSolPump", 16, 2, "hex2int", 1),
+            (4, "out", 26, 4, "raw", 1),
+            (5, "status", 30, 2, "raw", 1),
+        ],
+    )
+    def test_entries_match_fhem_16sol(self, index, name, offset, length, decode, factor):
+        entries = readings_map_439.REGISTER_MAP["pxx16"]
+        entry_name, entry_offset, entry_length, entry_decode, entry_factor = entries[index][:5]
+        assert entry_name.strip().rstrip(":") == name
+        assert (entry_offset, entry_length, entry_decode, entry_factor) == (
+            offset,
+            length,
+            decode,
+            factor,
+        )
+
+
+class TestFanBlockDefinition:
+    """Structural tests for the pxxE8 (sFan) block."""
+
+    def test_pxxe8_block_exists(self):
+        assert "pxxE8" in readings_map_439.REGISTER_MAP
+
+    def test_pxxe8_has_six_entries(self):
+        entries = readings_map_439.REGISTER_MAP["pxxE8"]
+        assert len(entries) == 6
+
+    @pytest.mark.parametrize(
+        "index,name,offset,length",
+        [
+            (0, "inputFanSpeed", 58, 2),
+            (1, "outputFanSpeed", 60, 2),
+            (2, "pFanstageXAirflowInlet", 62, 4),
+            (3, "pFanstageXAirflowOutlet", 66, 4),
+            (4, "inputFanPower", 70, 2),
+            (5, "outputFanPower", 72, 2),
+        ],
+    )
+    def test_entries_match_fhem_e8fan(self, index, name, offset, length):
+        entries = readings_map_439.REGISTER_MAP["pxxE8"]
+        entry_name, entry_offset, entry_length, entry_decode, _factor = entries[index][:5]
+        assert entry_name.strip().rstrip(":") == name
+        assert (entry_offset, entry_length, entry_decode) == (offset, length, "hex")
+
+
+class TestSolarEndToEndDecode:
+    """End-to-end decode of a synthetic pxx16 device response."""
+
+    @staticmethod
+    def _extract(message_hex: str, offset_nibbles: int, length_nibbles: int, decode_type: str, factor: float):
+        byte_offset = offset_nibbles // 2
+        byte_length = (length_nibbles + 1) // 2
+        raw = bytes.fromhex(message_hex)[byte_offset : byte_offset + byte_length]
+        return decode_raw_value(raw, decode_type, factor)
+
+    def _decode_block(self, message: bytes) -> dict:
+        message_hex = message.hex()
+        entries = readings_map_439.REGISTER_MAP["pxx16"]
+        results = {}
+        for entry in entries:
+            name, offset, length, decode, factor = entry[:5]
+            results[name.strip().rstrip(":")] = self._extract(
+                message_hex, offset, length, decode, factor
+            )
+        return results
+
+    def test_typical_solar_reading(self):
+        raw = bytearray(16)
+        raw[2], raw[3] = 0x01, 0xC8  # collectorTemp = 456 / 10 = 45.6
+        raw[4], raw[5] = 0x01, 0xF6  # dhwTemp = 502 / 10 = 50.2
+        raw[6], raw[7] = 0x01, 0xE3  # flowTemp = 483 / 10 = 48.3
+        raw[8] = 0x78  # edSolPump = 120
+        raw[13], raw[14] = 0xAB, 0xCD  # out (raw)
+        raw[15] = 0x02  # status (raw)
+
+        results = self._decode_block(bytes(raw))
+
+        assert results["collectorTemp"] == pytest.approx(45.6)
+        assert results["dhwTemp"] == pytest.approx(50.2)
+        assert results["flowTemp"] == pytest.approx(48.3)
+        assert results["edSolPump"] == 120
+        assert results["out"] == "abcd"
+        assert results["status"] == "02"
+
+
+class TestFanEndToEndDecode:
+    """End-to-end decode of a synthetic pxxE8 device response."""
+
+    @staticmethod
+    def _extract(message_hex: str, offset_nibbles: int, length_nibbles: int, decode_type: str, factor: float):
+        byte_offset = offset_nibbles // 2
+        byte_length = (length_nibbles + 1) // 2
+        raw = bytes.fromhex(message_hex)[byte_offset : byte_offset + byte_length]
+        return decode_raw_value(raw, decode_type, factor)
+
+    def _decode_block(self, message: bytes) -> dict:
+        message_hex = message.hex()
+        entries = readings_map_439.REGISTER_MAP["pxxE8"]
+        results = {}
+        for entry in entries:
+            name, offset, length, decode, factor = entry[:5]
+            results[name.strip().rstrip(":")] = self._extract(
+                message_hex, offset, length, decode, factor
+            )
+        return results
+
+    def test_typical_fan_reading(self):
+        raw = bytearray(37)
+        raw[29] = 50  # inputFanSpeed
+        raw[30] = 45  # outputFanSpeed
+        raw[31], raw[32] = 0x00, 0xB4  # pFanstageXAirflowInlet = 180 m3/h
+        raw[33], raw[34] = 0x00, 0xAF  # pFanstageXAirflowOutlet = 175 m3/h
+        raw[35] = 60  # inputFanPower
+        raw[36] = 55  # outputFanPower
+
+        results = self._decode_block(bytes(raw))
+
+        assert results["inputFanSpeed"] == 50
+        assert results["outputFanSpeed"] == 45
+        assert results["pFanstageXAirflowInlet"] == 180
+        assert results["pFanstageXAirflowOutlet"] == 175
+        assert results["inputFanPower"] == 60
+        assert results["outputFanPower"] == 55


### PR DESCRIPTION
Add solar circuit and live fan status blocks for firmware 4.39/5.39

Ports two more previously-unported FHEM blocks found via a systematic
audit against 00_THZ.pm:

- pxx16 (\"sSol\", command 16): solar circuit temperatures
  (collectorTemp/dhwTemp/flowTemp), solar pump runtime (edSolPump),
  and the raw out/status fields FHEM itself never decodes further.
- pxxE8 (\"sFan\", command E8): live input/output fan speed, airflow
  (m3/h), and fan power -- distinct from the existing p07-p12/p43-46/p99
  fan-stage *setting* write entities and from firmware 2.06's own
  differently-laid-out E8fan206 block.

const.py: adds a \"pxx16\": \"Solar Circuit\" label and renames the
existing \"pxxE8\" label from \"Air Flow Calibration\" to \"Fan Status &
Air Flow\", since that block ID is now shared between the pre-existing
write entries and this new read data.

Purely additive: no existing decode types, register entries, or
behavior change.