### PR TITLE
Add p99CoolingHC1AreaFan write entity

### DIFF
--- a/custom_components/thz/entity_translations.py
+++ b/custom_components/thz/entity_translations.py
@@ -187,6 +187,7 @@ ENTITY_TRANSLATION_KEYS = {
     # Cooling settings (p99 extended parameters)
     "p99CoolingHC1SetTemp": "cooling_hc1_set_temp",
     "p99CoolingHC1Switch": "cooling_hc1_switch",
+    "p99CoolingHC1AreaFan": "cooling_hc1_area_fan",
     "p99CoolingHC1HysterFlowTemp": "cooling_hc1_hyster_flow_temp",
     "p99CoolingHC1HysterRoomTemp": "cooling_hc1_hyster_room_temp",
     "p99CoolingHC2SetTemp": "cooling_hc2_set_temp",

--- a/custom_components/thz/register_maps/register_map_manager.py
+++ b/custom_components/thz/register_maps/register_map_manager.py
@@ -37,6 +37,7 @@ _COOLING_WRITE_KEYS: frozenset[str] = frozenset(
     {
         "p75passiveCooling",
         "p99CoolingHC1Switch",
+        "p99CoolingHC1AreaFan",
         "p99CoolingHC1SetTemp",
         "p99CoolingHC1HysterFlowTemp",
         "p99CoolingHC1HysterRoomTemp",

--- a/custom_components/thz/register_maps/write_map_539.py
+++ b/custom_components/thz/register_maps/write_map_539.py
@@ -121,6 +121,16 @@ WRITE_MAP = {
         "icon": "mdi:toggle-switch",
         "decode_type": "1clean",
     },
+    "p99CoolingHC1AreaFan": {
+        "command": "0B0613",
+        "min": "0",
+        "max": "1",
+        "unit": "",
+        "type": "switch",
+        "device_class": "",
+        "icon": "mdi:toggle-switch",
+        "decode_type": "1clean",
+    },
     "p99CoolingHC1SetTemp": {
         "command": "0B0582",
         "min": "12",

--- a/custom_components/thz/strings.json
+++ b/custom_components/thz/strings.json
@@ -1713,6 +1713,9 @@
       "cooling_hc1_switch": {
         "name": "Cooling HC1 Switch"
       },
+      "cooling_hc1_area_fan": {
+        "name": "Cooling HC1 Area Fan"
+      },
       "cooling_hc2_switch": {
         "name": "Cooling HC2 Switch"
       }

--- a/custom_components/thz/translations/de.json
+++ b/custom_components/thz/translations/de.json
@@ -1709,6 +1709,9 @@
       "cooling_hc1_switch": {
         "name": "Kühlung HK1 Schalter"
       },
+      "cooling_hc1_area_fan": {
+        "name": "Kühlung HK1 Flächenlüfter"
+      },
       "cooling_hc2_switch": {
         "name": "Kühlung HK2 Schalter"
       }

--- a/custom_components/thz/translations/en.json
+++ b/custom_components/thz/translations/en.json
@@ -1720,6 +1720,9 @@
       "cooling_hc1_switch": {
         "name": "Cooling HC1 Switch"
       },
+      "cooling_hc1_area_fan": {
+        "name": "Cooling HC1 Area Fan"
+      },
       "cooling_hc2_switch": {
         "name": "Cooling HC2 Switch"
       }


### PR DESCRIPTION
Adds p99CoolingHC1AreaFan (cooling-mode area fan control), found missing while cross-referencing the FHEM forum thread and 00_THZ.pm against the current write maps. Wires it into write_map_539.py, the entity_translations mapping, register_map_manager's cooling write-key set, and the strings/de/en translation files, following the same pattern as the existing p99CoolingHC1Switch entry.