### PR TITLE
Add climate preset_mode icons

### DIFF
--- a/custom_components/thz/icons.json
+++ b/custom_components/thz/icons.json
@@ -1,0 +1,54 @@
+{
+  "entity": {
+    "climate": {
+      "heating_circuit": {
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:thermostat",
+            "state": {
+              "standby": "mdi:power-standby",
+              "automatic": "mdi:calendar-sync",
+              "DAYmode": "mdi:white-balance-sunny",
+              "setback": "mdi:weather-night",
+              "DHWmode": "mdi:water-boiler",
+              "manual": "mdi:hand-back-right",
+              "emergency": "mdi:alert-octagon"
+            }
+          }
+        }
+      },
+      "heating_circuit_2": {
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:thermostat",
+            "state": {
+              "standby": "mdi:power-standby",
+              "automatic": "mdi:calendar-sync",
+              "DAYmode": "mdi:white-balance-sunny",
+              "setback": "mdi:weather-night",
+              "DHWmode": "mdi:water-boiler",
+              "manual": "mdi:hand-back-right",
+              "emergency": "mdi:alert-octagon"
+            }
+          }
+        }
+      },
+      "dhw_heating": {
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:thermostat",
+            "state": {
+              "standby": "mdi:power-standby",
+              "automatic": "mdi:calendar-sync",
+              "DAYmode": "mdi:white-balance-sunny",
+              "setback": "mdi:weather-night",
+              "DHWmode": "mdi:water-boiler",
+              "manual": "mdi:hand-back-right",
+              "emergency": "mdi:alert-octagon"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds per-state icons for the climate entities' preset_mode attribute (standby, automatic, DAYmode, setback, DHWmode, manual, emergency) -- the device-native operating-mode names. New file, no existing behavior change.

Note: these icons only take visible effect once preset_mode actually returns these state names, which depends on the still-unmerged Mode/Preset controls fix (separate PR). Adding the icons now is forward-compatible and harmless either way.