### PR TITLE
Add firmware_override config option

### DIFF
--- a/custom_components/thz/__init__.py
+++ b/custom_components/thz/__init__.py
@@ -20,8 +20,10 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    CONF_FIRMWARE_OVERRIDE,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
+    FIRMWARE_OVERRIDE_AUTO,
     WRITE_REGISTER_LENGTH,
     WRITE_REGISTER_OFFSET,
     should_hide_entity_by_default,
@@ -51,12 +53,22 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     data = config_entry.data
     conn_type = data["connection_type"]
+    firmware_override = data.get(CONF_FIRMWARE_OVERRIDE, FIRMWARE_OVERRIDE_AUTO)
 
     # 1. Initialize device
     if conn_type == "ip":
-        device = THZDevice(connection="ip", host=data["host"], tcp_port=data["port"])
+        device = THZDevice(
+            connection="ip",
+            host=data["host"],
+            tcp_port=data["port"],
+            firmware_override=firmware_override,
+        )
     elif conn_type == "usb":
-        device = THZDevice(connection="usb", port=data["device"])
+        device = THZDevice(
+            connection="usb",
+            port=data["device"],
+            firmware_override=firmware_override,
+        )
     else:
         raise ValueError("Invalid connection type")
 

--- a/custom_components/thz/config_flow.py
+++ b/custom_components/thz/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.helpers import area_registry as ar
 
 from .const import (
     CONF_CONNECTION_TYPE,
+    CONF_FIRMWARE_OVERRIDE,
     CONNECTION_IP,
     CONNECTION_USB,
     DEFAULT_BAUDRATE,
@@ -23,6 +24,8 @@ from .const import (
     DEFAULT_UPDATE_INTERVAL,
     DEFAULT_WRITE_INTERVAL,
     DOMAIN,
+    FIRMWARE_OVERRIDE_AUTO,
+    FIRMWARE_PROFILE_LABELS,
 )
 from .thz_device import THZDevice
 
@@ -245,6 +248,15 @@ class THZConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "area",
             default=defaults.get("area", ""),
         )] = vol.In(areas)
+
+        # Firmware profile override: "auto" keeps whatever the device itself
+        # reports; any other choice forces a specific FHEM-style profile
+        # (e.g. to add technician-level write entities, or to work around an
+        # auto-detected firmware string with no dedicated register-map entry).
+        schema_dict[vol.Optional(
+            CONF_FIRMWARE_OVERRIDE,
+            default=defaults.get(CONF_FIRMWARE_OVERRIDE, FIRMWARE_OVERRIDE_AUTO),
+        )] = vol.In(FIRMWARE_PROFILE_LABELS)
 
         # Refresh intervals for each block
         refresh_intervals = defaults.get("refresh_intervals", {})
@@ -479,10 +491,14 @@ class THZConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             refresh_intervals = {b: user_input[f"refresh_{b}"] for b in blocks}
             write_interval = user_input.get("write_interval", DEFAULT_WRITE_INTERVAL)
+            firmware_override = user_input.get(
+                CONF_FIRMWARE_OVERRIDE, FIRMWARE_OVERRIDE_AUTO
+            )
             data = {
                 **self.connection_data,
                 "refresh_intervals": refresh_intervals,
                 "write_interval": write_interval,
+                CONF_FIRMWARE_OVERRIDE: firmware_override,
             }
             conn_target = data.get("host") or data.get("device")
             title = f"THZ ({data['connection_type']}: {conn_target})"
@@ -499,6 +515,18 @@ class THZConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         schema_dict[write_key] = vol.All(
             int, vol.Range(min=5, max=86400)
         )
+
+        # Optional firmware profile override (defaults to auto-detect; the
+        # blocks listed above always reflect the auto-detected firmware,
+        # since block detection has to happen before an override could be
+        # chosen — switching to a profile from a different firmware family
+        # here won't retroactively change which blocks were detected. This
+        # is safe for same-family choices like plain "439" -> "439technician",
+        # which only adds write entities. To pick a different family's
+        # profile, use Reconfigure after initial setup instead.)
+        schema_dict[vol.Optional(
+            CONF_FIRMWARE_OVERRIDE, default=FIRMWARE_OVERRIDE_AUTO
+        )] = vol.In(FIRMWARE_PROFILE_LABELS)
 
         schema = vol.Schema(schema_dict)
         return self.async_show_form(

--- a/custom_components/thz/const.py
+++ b/custom_components/thz/const.py
@@ -33,6 +33,26 @@ DEFAULT_PORT = 2323
 DEFAULT_UPDATE_INTERVAL = 600  # in seconds
 DEFAULT_WRITE_INTERVAL = 3600  # in seconds, for write entities (number/switch/select/time)
 
+# Firmware profile override (config-flow "firmware_override" field).
+# "auto" keeps whatever firmware string the device itself reports; any other
+# value here is a FHEM-style profile key from register_map_manager's
+# FIRMWARE_MAPS, forced regardless of what the device reports. Useful when
+# auto-detection lands on an unlisted firmware string (e.g. an LWZ 403
+# reporting "438" instead of "439"), or when a user wants a specific profile
+# such as the technician variant independent of the raw detected value.
+CONF_FIRMWARE_OVERRIDE = "firmware_override"
+FIRMWARE_OVERRIDE_AUTO = "auto"
+FIRMWARE_PROFILE_LABELS: dict[str, str] = {
+    FIRMWARE_OVERRIDE_AUTO: "Auto-detect",
+    "206": "2.06",
+    "214": "2.14",
+    "214j": "2.14j",
+    "439": "4.39",
+    "439technician": "4.39 Technician",
+    "539": "5.39",
+    "539technician": "5.39 Technician",
+}
+
 # Write register offsets and lengths
 # These values are used when reading/writing individual parameters
 WRITE_REGISTER_OFFSET = 4  # Byte offset in response for parameter value

--- a/custom_components/thz/thz_device.py
+++ b/custom_components/thz/thz_device.py
@@ -42,6 +42,7 @@ class THZDevice:
         tcp_port: int | None = None,
         baudrate: int = const.DEFAULT_BAUDRATE,
         read_timeout: float = const.TIMEOUT,
+        firmware_override: str | None = None,
     ) -> None:
         """Initialize basic configuration – no communication yet."""
         self.connection = connection
@@ -50,6 +51,7 @@ class THZDevice:
         self.tcp_port = tcp_port
         self.baudrate = baudrate
         self.read_timeout = read_timeout
+        self._firmware_override = firmware_override
         self._initialized = False
 
         # Placeholders
@@ -88,11 +90,21 @@ class THZDevice:
         if self._firmware_version is None:
             raise RuntimeError("Firmware version could not be determined")
 
+        effective_firmware = self._resolve_effective_firmware()
+        if effective_firmware != self._firmware_version:
+            _LOGGER.info(
+                "Firmware profile overridden: detected %s, forcing %s",
+                self._firmware_version,
+                effective_firmware,
+            )
+
         # Probe for cooling support on 539-like firmware (v5.00+).
         # Devices like the LWZ404 run 539 firmware but lack cooling hardware;
         # they reply to cooling registers with an all-zero payload.
         # If detected, exclude the 539 cooling maps to avoid spurious entities.
-        fw_int = int(self._firmware_version) if self._firmware_version.isdigit() else 0
+        # This is keyed off the *effective* (possibly overridden) firmware,
+        # since that's what actually determines whether 539 cooling maps load.
+        fw_int = int(effective_firmware) if effective_firmware.isdigit() else 0
         if fw_int >= 500:
             self.has_cooling = await hass.async_add_executor_job(
                 self._probe_cooling_support
@@ -103,13 +115,28 @@ class THZDevice:
                 )
 
         self.register_map_manager = RegisterMapManager(
-            self._firmware_version, has_cooling=self.has_cooling
+            effective_firmware, has_cooling=self.has_cooling
         )
         self.write_register_map_manager = RegisterMapManagerWrite(
-            self._firmware_version, has_cooling=self.has_cooling
+            effective_firmware, has_cooling=self.has_cooling
         )
 
         self._initialized = True
+
+    def _resolve_effective_firmware(self) -> str:
+        """Return the firmware string to use for register-map selection.
+
+        Normally this is whatever the device itself reported
+        (``self._firmware_version``, kept as-is for display/diagnostics).
+        If a ``firmware_override`` was configured to anything other than
+        "auto", that value is used for register-map selection instead —
+        e.g. forcing "439technician" independent of the raw detected
+        value, or working around an auto-detected string with no dedicated
+        entry in ``FIRMWARE_MAPS``.
+        """
+        if self._firmware_override and self._firmware_override != const.FIRMWARE_OVERRIDE_AUTO:
+            return self._firmware_override
+        return self._firmware_version
 
     def _connect_serial(self):
         """Open the USB/Serial connection."""

--- a/tests/test_thz_device.py
+++ b/tests/test_thz_device.py
@@ -209,6 +209,64 @@ class TestFirmwareVersion:
     def test_firmware_version_none(self):
         """Test firmware_version raises error when not initialized."""
         device = THZDevice(connection="usb", port="/dev/null")
-        
+
         with pytest.raises(RuntimeError, match="Device not initialized"):
             _ = device.firmware_version
+
+
+class TestFirmwareOverride:
+    """Tests for the firmware_override config option and its resolution.
+
+    _resolve_effective_firmware() decides which firmware string actually
+    drives register-map selection: the auto-detected value, unless an
+    override was configured to force a specific FHEM-style profile (e.g.
+    "439technician") regardless of what the device reports.
+    """
+
+    def test_firmware_override_defaults_to_none(self):
+        """Test that no override is applied unless explicitly configured."""
+        device = THZDevice(connection="usb", port="/dev/null")
+        assert device._firmware_override is None
+
+    def test_firmware_override_stored(self):
+        """Test that a configured override is stored on the device."""
+        device = THZDevice(
+            connection="usb", port="/dev/null", firmware_override="539"
+        )
+        assert device._firmware_override == "539"
+
+    def test_no_override_uses_detected_firmware(self):
+        """Test that effective firmware falls back to the detected value."""
+        device = THZDevice(connection="usb", port="/dev/null")
+        device._firmware_version = "438"
+        assert device._resolve_effective_firmware() == "438"
+
+    def test_auto_override_uses_detected_firmware(self):
+        """Test that an explicit "auto" override behaves like no override."""
+        device = THZDevice(
+            connection="usb", port="/dev/null", firmware_override="auto"
+        )
+        device._firmware_version = "438"
+        assert device._resolve_effective_firmware() == "438"
+
+    def test_explicit_override_wins_over_detected_firmware(self):
+        """Test that a non-"auto" override takes precedence for map selection."""
+        device = THZDevice(
+            connection="usb", port="/dev/null", firmware_override="439technician"
+        )
+        device._firmware_version = "438"
+        assert device._resolve_effective_firmware() == "439technician"
+
+    def test_override_does_not_change_reported_firmware_version(self):
+        """Test that firmware_version still reflects the real detected value.
+
+        The override only affects which register maps get loaded; the
+        displayed/diagnostic firmware_version should stay truthful about
+        what the device actually reported.
+        """
+        device = THZDevice(
+            connection="usb", port="/dev/null", firmware_override="439technician"
+        )
+        device._firmware_version = "438"
+        assert device._resolve_effective_firmware() == "439technician"
+        assert device.firmware_version == "438"


### PR DESCRIPTION
Allows the detected firmware profile to be overridden via config flow, for cases where auto-detection picks the wrong register map (e.g. 206/214/214j/439/439technician/539/539technician variants that report ambiguous firmware strings).

- const.py: CONF_FIRMWARE_OVERRIDE, FIRMWARE_OVERRIDE_AUTO, and FIRMWARE_PROFILE_LABELS
- thz_device.py: _resolve_effective_firmware() resolves override vs detected firmware for register map selection
- __init__.py: reads firmware_override from config entry, passes it into THZDevice for both ip and usb transports
- config_flow.py: firmware_override dropdown in both the reconfigure flow and initial setup's refresh-intervals step
- test_thz_device.py: TestFirmwareOverride (6 tests) covering default, storage, no-override, explicit auto, override-wins, and that the reported firmware_version itself is unaffected by the override