### PR TITLE
Add entity_id_style and entity_visibility config options

### DIFF
--- a/custom_components/thz/__init__.py
+++ b/custom_components/thz/__init__.py
@@ -20,11 +20,16 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    CONF_ENTITY_ID_STYLE,
+    CONF_ENTITY_VISIBILITY,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
+    ENTITY_ID_STYLE_DEFAULT,
+    ENTITY_VISIBILITY_ALL,
+    ENTITY_VISIBILITY_DEFAULT,
     WRITE_REGISTER_LENGTH,
     WRITE_REGISTER_OFFSET,
-    should_hide_entity_by_default,
+    should_hide_entity,
 )
 from .thz_device import THZDevice
 
@@ -51,6 +56,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     data = config_entry.data
     conn_type = data["connection_type"]
+    entity_id_style = data.get(CONF_ENTITY_ID_STYLE, ENTITY_ID_STYLE_DEFAULT)
+    entity_visibility = data.get(CONF_ENTITY_VISIBILITY, ENTITY_VISIBILITY_DEFAULT)
+    # Short device name/alias, used (only for entity_id_style="fhem") as a
+    # prefix on every entity's technical entity_id, e.g.
+    # "lwz_p99start_unsched_vent". None when no alias was set, in which case
+    # the FHEM-style entity_id has no prefix at all.
+    entity_id_prefix = data.get("alias") or None
 
     # 1. Initialize device
     if conn_type == "ip":
@@ -170,6 +182,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         "register_manager": register_manager,
         "coordinators": coordinators,
         "unsupported_blocks": unsupported_blocks,
+        "entity_id_style": entity_id_style,
+        "entity_visibility": entity_visibility,
+        "entity_id_prefix": entity_id_prefix,
     }
 
     # Forward setup to platforms
@@ -178,10 +193,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         ["sensor", "binary_sensor", "number", "switch", "select", "time", "button", "climate"],
     )
 
-    # One-time migration: disable entities that should be hidden by default
-    # (program schedules, HC2, advanced parameters) for users upgrading from
-    # older versions where these entities were registered as enabled.
-    await _async_migrate_disable_hidden_entities(hass, config_entry)
+    # Apply the configured entity_visibility tier (default/extended/all) to
+    # the entity registry. Re-runs (and retroactively bulk enables/disables
+    # entities) whenever the configured tier differs from the tier last
+    # applied, e.g. after the user changes this option via Reconfigure.
+    await _async_apply_entity_visibility_tier(hass, config_entry)
 
     # Register services
     await _async_setup_services(hass)
@@ -646,39 +662,76 @@ async def _async_setup_services(hass: HomeAssistant) -> None:
     _LOGGER.info("THZ services registered")
 
 
-async def _async_migrate_disable_hidden_entities(
+def _entity_should_be_hidden(uid: str, name: str, visibility: str) -> bool:
+    """Determine whether an existing registry entity should be hidden.
+
+    Checks both the unique_id and the display/original name against the
+    visibility classifier, plus a legacy raw "program" substring check on
+    the unique_id (kept for backward compatibility with entities registered
+    before the name-based classifier existed).
+
+    Args:
+        uid: The entity's unique_id, lower-cased.
+        name: The entity's original/display name, lower-cased.
+        visibility: "default"/"extended"/"all" (see const.should_hide_entity).
+    """
+    if should_hide_entity(uid, visibility) or should_hide_entity(name, visibility):
+        return True
+    if "program" in uid and visibility != ENTITY_VISIBILITY_ALL:
+        # Schedules are hidden in both "default" and "extended" tiers; this
+        # catches entities whose unique_id contains "program" but whose
+        # name-based classification missed it for some reason.
+        return True
+    return False
+
+
+async def _async_apply_entity_visibility_tier(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> None:
-    """One-time migration: disable entities that should be hidden by default.
+    """Apply the configured entity_visibility tier to the entity registry.
 
-    When upgrading from older versions, program/schedule, HC2, and advanced
-    parameter entities may already be registered as enabled. This migration
-    disables them once so they no longer clutter the UI.
+    Unlike a one-time migration, this re-runs whenever the configured tier
+    differs from the tier last applied — e.g. after the user changes this
+    option via Reconfigure — so it retroactively bulk enables/disables
+    entities on an existing install rather than only affecting entities
+    created from now on.
 
-    Entities explicitly re-enabled by the user afterwards will stay enabled
-    because the migration only runs once (guarded by a stored flag).
+    To avoid overriding a user's own manual choice, this only:
+      - re-enables entities that are currently disabled_by INTEGRATION
+        (i.e. disabled by a previous run of this same function), and
+      - newly disables entities that are currently enabled
+        (disabled_by is None).
+    An entity the user disabled themselves (disabled_by == USER) is never
+    touched.
 
     Args:
         hass: The Home Assistant instance.
-        config_entry: The config entry to migrate entities for.
+        config_entry: The config entry to reconcile entities for.
     """
-    if config_entry.data.get("_hidden_entities_migrated"):
+    visibility = config_entry.data.get(
+        CONF_ENTITY_VISIBILITY, ENTITY_VISIBILITY_DEFAULT
+    )
+
+    last_applied = config_entry.data.get("_entity_visibility_applied")
+    if last_applied is None and config_entry.data.get("_hidden_entities_migrated"):
+        # Backward compatibility: the old one-time migration already ran and
+        # enforced the "default" tier's hidden set. Treat that as equivalent
+        # to having applied the "default" tier once.
+        last_applied = ENTITY_VISIBILITY_DEFAULT
+
+    if last_applied == visibility:
         return
 
     ent_reg = er.async_get(hass)
     entries = er.async_entries_for_config_entry(ent_reg, config_entry.entry_id)
+
+    enabled_count = 0
     disabled_count = 0
 
     for entity_entry in entries:
-        # Check unique_id for program/hc2 patterns (most reliable identifier)
         uid = (entity_entry.unique_id or "").lower()
         name = (entity_entry.original_name or entity_entry.name or "").lower()
-
-        should_hide = (
-            should_hide_entity_by_default(uid)
-            or should_hide_entity_by_default(name)
-            or "program" in uid
-        )
+        should_hide = _entity_should_be_hidden(uid, name, visibility)
 
         if should_hide and entity_entry.disabled_by is None:
             ent_reg.async_update_entity(
@@ -687,36 +740,69 @@ async def _async_migrate_disable_hidden_entities(
             )
             disabled_count += 1
             _LOGGER.debug(
-                "Migration: disabled hidden entity %s (uid=%s)",
-                entity_entry.entity_id,
-                entity_entry.unique_id,
+                "Entity visibility: disabled %s (uid=%s) for tier '%s'",
+                entity_entry.entity_id, entity_entry.unique_id, visibility,
+            )
+        elif (
+            not should_hide
+            and entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+        ):
+            ent_reg.async_update_entity(entity_entry.entity_id, disabled_by=None)
+            enabled_count += 1
+            _LOGGER.debug(
+                "Entity visibility: re-enabled %s (uid=%s) for tier '%s'",
+                entity_entry.entity_id, entity_entry.unique_id, visibility,
             )
 
-    if disabled_count:
+    if disabled_count or enabled_count:
         _LOGGER.info(
-            "Migration: disabled %d program/HC2/advanced entities", disabled_count
+            "Entity visibility tier '%s' applied: disabled %d entities, "
+            "re-enabled %d entities",
+            visibility, disabled_count, enabled_count,
         )
 
-    # Store flag so this migration only runs once
+    # Store the applied tier so this only re-runs when the tier changes
     hass.config_entries.async_update_entry(
         config_entry,
-        data={**config_entry.data, "_hidden_entities_migrated": True},
+        data={**config_entry.data, "_entity_visibility_applied": visibility},
     )
 
 
 async def _async_cleanup_orphaned_entities(hass: HomeAssistant) -> None:
     """Remove orphaned THZ entities from the entity registry.
 
-    Orphaned entities are those with platform="thz" but config_entry_id=None.
-    These can occur when the integration is deleted but HA doesn't fully clean up
-    the entity registry entries, leaving "ghost" entities with broken names.
+    An entity is orphaned if it has platform="thz" and its config_entry_id
+    either is None, or no longer refers to any config entry that actually
+    exists. Both cases can occur when the integration is deleted:
+
+    - config_entry_id=None: HA nulled the reference out (the case this
+      function originally handled).
+    - config_entry_id=<stale id>: HA left the entity pointing at the
+      now-deleted entry's id instead of nulling it. This is the more common
+      case in practice, and the original None-only check missed it entirely
+      -- the entity registry row (including its unique_id) survives every
+      "Delete integration" cycle, and the *next* time the integration is
+      added, entity_registry.async_get_or_create() matches the pre-existing
+      unique_id and silently reattaches to this same old row, reusing its
+      original entity_id forever. Since suggested_object_id (the mechanism
+      entity_id_style/entity_id_prefix rely on) is only consulted the very
+      first time a row is created for a given unique_id, a stale reattached
+      row never picks up entity_id_style/alias changes made after that row's
+      original creation, no matter how many times the integration is
+      removed and re-added with different settings.
     """
     entity_reg = er.async_get(hass)
     orphaned_count = 0
 
     # Get all entities and filter for orphaned THZ entities
     for entity in list(entity_reg.entities.values()):
-        if entity.platform == "thz" and entity.config_entry_id is None:
+        if entity.platform != "thz":
+            continue
+        config_entry_id = entity.config_entry_id
+        is_orphaned = config_entry_id is None or (
+            hass.config_entries.async_get_entry(config_entry_id) is None
+        )
+        if is_orphaned:
             entity_reg.async_remove(entity.entity_id)
             _LOGGER.debug("Removed orphaned THZ entity: %s", entity.entity_id)
             orphaned_count += 1

--- a/custom_components/thz/base_entity.py
+++ b/custom_components/thz/base_entity.py
@@ -14,7 +14,14 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN, should_hide_entity_by_default
+from .const import (
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    ENTITY_ID_STYLE_DEFAULT,
+    ENTITY_VISIBILITY_DEFAULT,
+    should_hide_entity,
+)
+from .entity_id_style import resolve_suggested_object_id
 
 if TYPE_CHECKING:
     from .thz_device import THZDevice
@@ -41,6 +48,10 @@ class THZBaseEntity(Entity):
         unique_id: str | None = None,
         scan_interval: int | None = None,
         translation_key: str | None = None,
+        entity_id_style: str = ENTITY_ID_STYLE_DEFAULT,
+        entity_visibility: str = ENTITY_VISIBILITY_DEFAULT,
+        entity_id_prefix: str | None = None,
+        domain: str | None = None,
     ) -> None:
         """Initialize base THZ entity.
 
@@ -54,6 +65,23 @@ class THZBaseEntity(Entity):
             scan_interval: Update interval in seconds (uses DEFAULT_UPDATE_INTERVAL if
                 not provided).
             translation_key: Optional translation key for localization.
+            entity_id_style: One of the ``ENTITY_ID_STYLE_*`` values from
+                const.py. "fhem" sets ``self.entity_id`` directly from the
+                raw ``name`` so a brand-new entity's entity_id reads like the
+                FHEM/Stiebel field name; the displayed name and unique_id are
+                unaffected either way. See entity_id_style.py.
+            entity_visibility: One of the ``ENTITY_VISIBILITY_*`` values from
+                const.py, controlling whether this entity starts out enabled
+                or disabled in the entity registry. See should_hide_entity().
+            entity_id_prefix: Optional device name/alias (e.g. "lwz") to
+                prepend to the FHEM-style entity_id, e.g.
+                "lwz_p99start_unsched_vent". Only used when entity_id_style
+                is "fhem"; ignored otherwise. See resolve_suggested_object_id().
+            domain: The HA entity platform domain this entity belongs to
+                (e.g. "number", "switch"). Required for entity_id_style
+                "fhem" to take effect -- see the ``self.entity_id`` note
+                below. Each concrete subclass hardcodes its own domain when
+                calling super().__init__().
         """
         self._command = command
         self._device = device
@@ -81,6 +109,26 @@ class THZBaseEntity(Entity):
             unique_id or self._generate_unique_id(command, name)
         )
 
+        # Entity-ID naming style: independent of unique_id/translation_key
+        # (see resolve_suggested_object_id's docstring for details). Only
+        # takes effect the first time HA creates this entity.
+        #
+        # IMPORTANT: Home Assistant's Entity class has no "_attr_suggested_object_id"
+        # hook -- Entity.suggested_object_id is a read-only @property computed from
+        # self.name/translations, and never reads any "_attr_*" instance attribute.
+        # Setting one (as this code used to do) is a silent no-op: HA falls straight
+        # through to its own has_entity_name/device-name/area-based naming instead.
+        #
+        # The actually-supported mechanism (see entity_platform.py's
+        # EntityPlatform._async_add_entity) is to set self.entity_id directly
+        # *before* the entity is added to hass: if entity.entity_id is already set,
+        # HA uses it verbatim as the suggested object_id instead of deriving one.
+        suggested_object_id = resolve_suggested_object_id(
+            name, entity_id_style, device_prefix=entity_id_prefix
+        )
+        if suggested_object_id and domain:
+            self.entity_id = f"{domain}.{suggested_object_id}"
+
         # Debug log entity attributes
         _LOGGER.debug(
             "Entity %s initialized: has_entity_name=%s, name=%s, translation_key=%s",
@@ -96,19 +144,21 @@ class THZBaseEntity(Entity):
         self._update_interval = timedelta(seconds=interval)
         self._unsub_update: Callable[[], None] | None = None
 
-        # Set default visibility based on entity naming conventions
+        # Set default visibility based on entity naming conventions and the
+        # configured entity_visibility tier.
         # Uses HA's standard _attr_ pattern – do NOT add an explicit @property
         # override; it conflicts with HA's __init_subclass__ CachedProperty
         # mechanism and can silently default to True on derived entity classes.
-        self._attr_entity_registry_enabled_default = not should_hide_entity_by_default(
-            name
+        self._attr_entity_registry_enabled_default = not should_hide_entity(
+            name, entity_visibility
         )
 
         _LOGGER.debug(
-            "Entity %s: entity_registry_enabled_default=%s (hide=%s)",
+            "Entity %s: entity_registry_enabled_default=%s (hide=%s, visibility=%s)",
             name,
             self._attr_entity_registry_enabled_default,
-            should_hide_entity_by_default(name),
+            should_hide_entity(name, entity_visibility),
+            entity_visibility,
         )
 
     def _generate_unique_id(self, command: str, name: str) -> str:

--- a/custom_components/thz/binary_sensor.py
+++ b/custom_components/thz/binary_sensor.py
@@ -24,7 +24,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, should_hide_entity_by_default
+from .const import (
+    DOMAIN,
+    ENTITY_ID_STYLE_DEFAULT,
+    ENTITY_VISIBILITY_DEFAULT,
+    should_hide_entity,
+)
+from .entity_id_style import resolve_suggested_object_id
 from .register_maps.register_map_manager import RegisterMapManager
 from .value_codec import decode_raw_value
 
@@ -87,6 +93,9 @@ async def async_setup_entry(
     register_manager: RegisterMapManager = entry_data["register_manager"]
     coordinators = entry_data["coordinators"]
     device_id = entry_data["device_id"]
+    entity_id_style = entry_data.get("entity_id_style", ENTITY_ID_STYLE_DEFAULT)
+    entity_visibility = entry_data.get("entity_visibility", ENTITY_VISIBILITY_DEFAULT)
+    entity_id_prefix = entry_data.get("entity_id_prefix")
 
     entities: list[THZBinarySensor] = []
     seen_sensor_names: set[str] = set()
@@ -146,7 +155,13 @@ async def async_setup_entry(
             }
             entities.append(
                 THZBinarySensor(
-                    coordinator, entry=entry, block=block_bytes, device_id=device_id
+                    coordinator,
+                    entry=entry,
+                    block=block_bytes,
+                    device_id=device_id,
+                    entity_id_style=entity_id_style,
+                    entity_visibility=entity_visibility,
+                    entity_id_prefix=entity_id_prefix,
                 )
             )
 
@@ -175,6 +190,9 @@ class THZBinarySensor(CoordinatorEntity, BinarySensorEntity):
         entry: dict[str, Any],
         block: bytes,
         device_id: str,
+        entity_id_style: str = ENTITY_ID_STYLE_DEFAULT,
+        entity_visibility: str = ENTITY_VISIBILITY_DEFAULT,
+        entity_id_prefix: str | None = None,
     ) -> None:
         """Initialize a THZBinarySensor.
 
@@ -184,6 +202,11 @@ class THZBinarySensor(CoordinatorEntity, BinarySensorEntity):
                 translation_key.
             block: Block address bytes (hex) identifying the register.
             device_id: Device identifier for linking this entity to the device.
+            entity_id_style: "default" or "fhem" (see entity_id_style.py).
+            entity_visibility: "default"/"extended"/"all" (see const.py's
+                should_hide_entity()).
+            entity_id_prefix: Optional device alias prefix for "fhem"-style
+                entity_ids (see entity_id_style.py).
         """
         super().__init__(coordinator)
 
@@ -207,10 +230,23 @@ class THZBinarySensor(CoordinatorEntity, BinarySensorEntity):
         # Device class improves UI representation and enables automations
         self._attr_device_class = _get_device_class(self._entity_name)
 
-        # Visibility: hide advanced/technical entities by default
+        # Visibility: hide advanced/technical entities per the configured tier
         self._attr_entity_registry_enabled_default = (
-            not should_hide_entity_by_default(self._entity_name)
+            not should_hide_entity(self._entity_name, entity_visibility)
         )
+
+        # Entity-ID naming style: independent of translation_key/unique_id.
+        # NOTE: Home Assistant has no "_attr_suggested_object_id" hook --
+        # Entity.suggested_object_id is a read-only @property, never backed by
+        # an "_attr_*" instance attribute. Setting self.entity_id directly
+        # (before this entity is added to hass) is the actually-supported way
+        # to seed a custom initial object_id -- see base_entity.py's
+        # THZBaseEntity.__init__ for the full explanation.
+        suggested_object_id = resolve_suggested_object_id(
+            self._entity_name, entity_id_style, device_prefix=entity_id_prefix
+        )
+        if suggested_object_id:
+            self.entity_id = f"binary_sensor.{suggested_object_id}"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/thz/button.py
+++ b/custom_components/thz/button.py
@@ -57,6 +57,9 @@ class THZButton(THZBaseEntity, ButtonEntity):
         device: THZDevice,
         device_id: str,
         scan_interval: int | None = None,
+        entity_id_style: str = "default",
+        entity_visibility: str = "default",
+        entity_id_prefix: str | None = None,
     ) -> None:
         """Initialize a THZ button entity.
 
@@ -66,6 +69,10 @@ class THZButton(THZBaseEntity, ButtonEntity):
             device: The device instance this button communicates with.
             device_id: The device identifier for registry linking.
             scan_interval: Not used for buttons; accepted for API compatibility.
+            entity_id_style: "default" or "fhem" (see base_entity.py).
+            entity_visibility: "default"/"extended"/"all" (see base_entity.py).
+            entity_id_prefix: Optional device alias prefix for "fhem"-style
+                entity_ids (see base_entity.py).
         """
         super().__init__(
             name=name,
@@ -75,6 +82,10 @@ class THZButton(THZBaseEntity, ButtonEntity):
             icon=entry.get("icon") or "mdi:gesture-tap-button",
             scan_interval=scan_interval,
             translation_key=get_translation_key(name),
+            entity_id_style=entity_id_style,
+            entity_visibility=entity_visibility,
+            entity_id_prefix=entity_id_prefix,
+            domain="button",
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/thz/climate.py
+++ b/custom_components/thz/climate.py
@@ -52,7 +52,13 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import DOMAIN, WRITE_REGISTER_LENGTH, WRITE_REGISTER_OFFSET
+from .const import (
+    DOMAIN,
+    ENTITY_ID_STYLE_DEFAULT,
+    WRITE_REGISTER_LENGTH,
+    WRITE_REGISTER_OFFSET,
+)
+from .entity_id_style import resolve_suggested_object_id
 from .value_codec import THZValueCodec, decode_raw_value
 
 _LOGGER = logging.getLogger(__name__)
@@ -200,6 +206,8 @@ async def async_setup_entry(
     device_id: str = entry_data["device_id"]
     write_registers: dict = entry_data["write_manager"].get_all_registers()
     register_manager = entry_data["register_manager"]
+    entity_id_style = entry_data.get("entity_id_style", ENTITY_ID_STYLE_DEFAULT)
+    entity_id_prefix = entry_data.get("entity_id_prefix")
 
     # Derive field byte-offsets and lengths from the active firmware's register map.
     # Returns None when a field is absent; the entity is skipped in that case.
@@ -268,6 +276,8 @@ async def async_setup_entry(
                     cool_setpoint_entry=cool_setpoint_entry,
                     opmode_entry=opmode_entry,
                     fan_stage_entry=fan_stage_entry,
+                    entity_id_style=entity_id_style,
+                    entity_id_prefix=entity_id_prefix,
                 )
             )
 
@@ -310,6 +320,8 @@ async def async_setup_entry(
                         cool_switch_entry=hc2_cool_switch_entry,
                         cool_setpoint_entry=hc2_cool_setpoint_entry,
                         opmode_entry=opmode_entry,
+                        entity_id_style=entity_id_style,
+                        entity_id_prefix=entity_id_prefix,
                     )
                 )
 
@@ -336,6 +348,8 @@ async def async_setup_entry(
                     heat_setpoint_entry=dhw_entry,
                     cool_switch_entry=None,
                     cool_setpoint_entry=None,
+                    entity_id_style=entity_id_style,
+                    entity_id_prefix=entity_id_prefix,
                 )
             )
 
@@ -473,6 +487,8 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
         cooling_byte: int | None = None,
         cooling_bit: int | None = None,
         compressor_bit: int | None = None,
+        entity_id_style: str = ENTITY_ID_STYLE_DEFAULT,
+        entity_id_prefix: str | None = None,
     ) -> None:
         """Initialise a THZ climate entity.
 
@@ -496,6 +512,18 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
                 register (``pOpMode``).  Enables preset mode when provided.
             fan_stage_entry: Write-register metadata for the day fan-stage
                 register (``p07FanStageDay``).  Enables fan mode when provided.
+            entity_id_style: One of the ``ENTITY_ID_STYLE_*`` values from
+                const.py. "fhem" sets ``self.entity_id`` directly (using
+                ``translation_key`` as the raw name, since a climate entity
+                is a synthesized composite of several registers rather than
+                one single FHEM parameter) so a brand-new entity's entity_id
+                doesn't fall back to Home Assistant's own device/area-based
+                naming. See entity_id_style.py and base_entity.py's
+                THZBaseEntity.__init__ for why this can't just be
+                "_attr_suggested_object_id".
+            entity_id_prefix: Optional device name/alias (e.g. "lwz") to
+                prepend to the FHEM-style entity_id. Only used when
+                entity_id_style is "fhem"; ignored otherwise.
         """
         super().__init__(coordinator)
 
@@ -526,6 +554,19 @@ class THZClimate(CoordinatorEntity, ClimateEntity):
         self._fan_stage_cache: int | None = None
 
         self._attr_translation_key = translation_key
+
+        # Entity-ID naming style: independent of translation_key/unique_id.
+        # NOTE: Home Assistant has no "_attr_suggested_object_id" hook --
+        # Entity.suggested_object_id is a read-only @property, never backed by
+        # an "_attr_*" instance attribute. Setting self.entity_id directly
+        # (before this entity is added to hass) is the actually-supported way
+        # to seed a custom initial object_id -- see base_entity.py's
+        # THZBaseEntity.__init__ for the full explanation.
+        suggested_object_id = resolve_suggested_object_id(
+            translation_key, entity_id_style, device_prefix=entity_id_prefix
+        )
+        if suggested_object_id:
+            self.entity_id = f"climate.{suggested_object_id}"
 
         # Unique ID based on coordinator name and translation key
         safe_key = translation_key.lower().replace(" ", "_")

--- a/custom_components/thz/config_flow.py
+++ b/custom_components/thz/config_flow.py
@@ -16,6 +16,8 @@ from homeassistant.helpers import area_registry as ar
 
 from .const import (
     CONF_CONNECTION_TYPE,
+    CONF_ENTITY_ID_STYLE,
+    CONF_ENTITY_VISIBILITY,
     CONNECTION_IP,
     CONNECTION_USB,
     DEFAULT_BAUDRATE,
@@ -23,6 +25,10 @@ from .const import (
     DEFAULT_UPDATE_INTERVAL,
     DEFAULT_WRITE_INTERVAL,
     DOMAIN,
+    ENTITY_ID_STYLE_DEFAULT,
+    ENTITY_ID_STYLE_LABELS,
+    ENTITY_VISIBILITY_DEFAULT,
+    ENTITY_VISIBILITY_LABELS,
 )
 from .thz_device import THZDevice
 
@@ -45,10 +51,20 @@ class THZConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self.connection_data = {}
         self.blocks = []
+        self.entity_id_style = ENTITY_ID_STYLE_DEFAULT
+        self.entity_visibility = ENTITY_VISIBILITY_DEFAULT
+        self.alias = ""
 
     async def async_step_user(self, user_input=None) -> config_entries.ConfigFlowResult:
-        """First step, select connection type."""
+        """First step, select connection type and entity naming style."""
         if user_input is not None:
+            self.entity_id_style = user_input.get(
+                CONF_ENTITY_ID_STYLE, ENTITY_ID_STYLE_DEFAULT
+            )
+            self.entity_visibility = user_input.get(
+                CONF_ENTITY_VISIBILITY, ENTITY_VISIBILITY_DEFAULT
+            )
+            self.alias = user_input.get("alias", "").strip()
             if user_input["connection_type"] == CONNECTION_IP:
                 return await self.async_step_setup_ip()
             return await self.async_step_setup_usb()
@@ -61,6 +77,28 @@ class THZConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONNECTION_USB: "USB / Serial",
                     }
                 ),
+                # Optional short device name/alias (e.g. "lwz"). Shown as the
+                # device name in HA, and -- when entity_id_style is "fhem" --
+                # prepended to every entity's technical entity_id (e.g.
+                # "lwz_p99start_unsched_vent") so it stays short and
+                # recognisable instead of falling back to a generic default.
+                vol.Optional("alias", default=""): str,
+                # Entity ID naming style, asked up front since it applies to
+                # every entity created during this setup. "fhem" only
+                # changes entity_id (via suggested_object_id) for newly
+                # created entities -- it never touches the displayed name.
+                vol.Optional(
+                    CONF_ENTITY_ID_STYLE, default=ENTITY_ID_STYLE_DEFAULT
+                ): vol.In(ENTITY_ID_STYLE_LABELS),
+                # Entity visibility tier: which less-common entities (HC2,
+                # schedules, advanced technical parameters) start enabled.
+                # "default" hides all of them (matching prior behavior),
+                # "extended" enables everything except schedules, "all"
+                # enables everything. Can be changed later via Reconfigure,
+                # which retroactively bulk enables/disables existing entities.
+                vol.Optional(
+                    CONF_ENTITY_VISIBILITY, default=ENTITY_VISIBILITY_DEFAULT
+                ): vol.In(ENTITY_VISIBILITY_LABELS),
             }
         )
         return self.async_show_form(step_id="user", data_schema=schema)
@@ -245,6 +283,26 @@ class THZConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "area",
             default=defaults.get("area", ""),
         )] = vol.In(areas)
+
+        # Entity ID naming style: purely cosmetic, does not affect device
+        # communication. "fhem" only changes HA's suggested_object_id for a
+        # BRAND NEW entity -- it has no effect on entities that already
+        # exist in the registry (their entity_id stays whatever it already
+        # is). Only newly-added blocks/entities, or ones removed and
+        # recreated, pick up the new style after switching this here.
+        schema_dict[vol.Optional(
+            CONF_ENTITY_ID_STYLE,
+            default=defaults.get(CONF_ENTITY_ID_STYLE, ENTITY_ID_STYLE_DEFAULT),
+        )] = vol.In(ENTITY_ID_STYLE_LABELS)
+
+        # Entity visibility tier: unlike entity_id_style, changing this HERE
+        # retroactively bulk enables/disables entities already in the
+        # registry (see _async_apply_entity_visibility_tier in __init__.py),
+        # not just newly-created ones.
+        schema_dict[vol.Optional(
+            CONF_ENTITY_VISIBILITY,
+            default=defaults.get(CONF_ENTITY_VISIBILITY, ENTITY_VISIBILITY_DEFAULT),
+        )] = vol.In(ENTITY_VISIBILITY_LABELS)
 
         # Refresh intervals for each block
         refresh_intervals = defaults.get("refresh_intervals", {})
@@ -483,6 +541,13 @@ class THZConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 **self.connection_data,
                 "refresh_intervals": refresh_intervals,
                 "write_interval": write_interval,
+                CONF_ENTITY_ID_STYLE: getattr(
+                    self, "entity_id_style", ENTITY_ID_STYLE_DEFAULT
+                ),
+                CONF_ENTITY_VISIBILITY: getattr(
+                    self, "entity_visibility", ENTITY_VISIBILITY_DEFAULT
+                ),
+                "alias": getattr(self, "alias", ""),
             }
             conn_target = data.get("host") or data.get("device")
             title = f"THZ ({data['connection_type']}: {conn_target})"

--- a/custom_components/thz/const.py
+++ b/custom_components/thz/const.py
@@ -33,6 +33,55 @@ DEFAULT_PORT = 2323
 DEFAULT_UPDATE_INTERVAL = 600  # in seconds
 DEFAULT_WRITE_INTERVAL = 3600  # in seconds, for write entities (number/switch/select/time)
 
+# Entity ID naming style (config-flow "entity_id_style" field).
+# "default" keeps this integration's own descriptive entity_id slugs
+# (unchanged behaviour). "fhem" instead derives the entity_id from the RAW
+# internal register-map/parameter name -- which, for the large majority of
+# entries, IS already FHEM's own 00_THZ.pm field name or Stiebel Eltron's
+# official parameter number (e.g. "dhwPump", "collectorTemp",
+# "p01RoomTempDayHC1") since this integration was ported from those same
+# tables -- run through a simple camelCase->snake_case slug (see
+# entity_id_style.py). This is purely cosmetic: it only ever changes HA's
+# *suggested* entity_id for a BRAND NEW entity (via _attr_suggested_object_id)
+# and never touches unique_id or the displayed friendly name, so switching it
+# does not rename or break any entity that already exists in the registry.
+# Intended to make dashboards/automations ported from FHEM easier to read
+# for FHEM users migrating to this integration.
+CONF_ENTITY_ID_STYLE = "entity_id_style"
+ENTITY_ID_STYLE_DEFAULT = "default"
+ENTITY_ID_STYLE_FHEM = "fhem"
+ENTITY_ID_STYLE_LABELS: dict[str, str] = {
+    ENTITY_ID_STYLE_DEFAULT: "Default (descriptive)",
+    ENTITY_ID_STYLE_FHEM: "FHEM/technical (matches 00_THZ.pm field names & Stiebel parameter numbers)",
+}
+
+# Entity visibility tier (config-flow "entity_visibility" field).
+# Controls how many entities are enabled-by-default at creation time, to
+# avoid the tedium of enabling dozens of individually-disabled entities by
+# hand. Three tiers, from fewest to most entities enabled:
+#   "default"  - hides HC2 entities, schedule/program entities, and advanced
+#                technical parameters (p13+, hysteresis, gradient, booster
+#                timing, etc.) -- this integration's long-standing behaviour.
+#   "extended" - enables everything EXCEPT schedule/program entities (there
+#                are ~120+ of these per firmware, one per day-of-week/slot
+#                combination, which is what makes them "lengthy").
+#   "all"      - enables every entity, including schedules.
+# Selectable at initial setup and, unlike entity_id_style/firmware_override,
+# ALSO retroactively reconciles the entity registry when changed later via
+# Reconfigure (see __init__.py's _async_apply_entity_visibility_tier) --
+# entities the integration previously disabled to match an older tier get
+# re-enabled (or newly disabled) to match the new one. An entity a user has
+# manually toggled by hand is left alone either way.
+CONF_ENTITY_VISIBILITY = "entity_visibility"
+ENTITY_VISIBILITY_DEFAULT = "default"
+ENTITY_VISIBILITY_EXTENDED = "extended"
+ENTITY_VISIBILITY_ALL = "all"
+ENTITY_VISIBILITY_LABELS: dict[str, str] = {
+    ENTITY_VISIBILITY_DEFAULT: "Default (hide HC2, schedules, and advanced parameters)",
+    ENTITY_VISIBILITY_EXTENDED: "Extended (enable everything except schedule/program entities)",
+    ENTITY_VISIBILITY_ALL: "All (enable everything, including schedules)",
+}
+
 # Write register offsets and lengths
 # These values are used when reading/writing individual parameters
 WRITE_REGISTER_OFFSET = 4  # Byte offset in response for parameter value
@@ -107,29 +156,36 @@ BLOCK_LABELS: dict[str, str] = {
 }
 
 
-def should_hide_entity_by_default(entity_name: str) -> bool:
-    """Determine if an entity should be hidden by default.
+def _classify_hidden_category(entity_name: str) -> str | None:
+    """Classify entity_name into a hiding category, or None if never hidden.
 
-    Entities are hidden if they:
-    - Are related to HC2 (heating circuit 2)
-    - Are time plan/program schedules
-    - Are advanced technical parameters that most users don't need
+    Two categories, matched in this order:
+        "schedule" - time plan/program entities (there are ~120+ of these per
+            firmware -- one per day-of-week/time-slot combination -- which is
+            what makes them "lengthy").
+        "advanced" - HC2 (heating circuit 2) entities, and advanced technical
+            parameters (p13 and above, plus keyword-matched settings like
+            hysteresis, gradient, booster timing, etc.) that most users don't
+            need to see or adjust day-to-day.
 
     Args:
-        entity_name: The name of the entity to check.
+        entity_name: The name of the entity to classify.
 
     Returns:
-        True if the entity should be hidden by default, False otherwise.
+        "schedule", "advanced", or None if the entity is never hidden by any
+        visibility tier.
     """
     name_lower = entity_name.lower()
 
-    # Hide all HC2-related entities
-    # Hide all time plan/program entities
-    if "hc2" in name_lower or "program" in name_lower:
-        return True
+    # Time plan/program entities
+    if "program" in name_lower:
+        return "schedule"
 
-    # Hide advanced technical parameters
-    # These are parameters p13-p99 which are technical settings
+    # HC2-related entities
+    if "hc2" in name_lower:
+        return "advanced"
+
+    # Advanced technical parameters: p13-p99 which are technical settings
     # that most users don't need to adjust
     if name_lower.startswith("p") and len(name_lower) > 2:
         # Check if it starts with p followed by digits
@@ -143,11 +199,11 @@ def should_hide_entity_by_default(entity_name: str) -> bool:
 
         if digit_str:
             param_num = int(digit_str)
-            # Hide technical parameters p13 and above (gradient, hysteresis, etc.)
+            # p13 and above (gradient, hysteresis, etc.)
             if param_num >= 13:
-                return True
+                return "advanced"
 
-    # Hide specific advanced/technical sensors
+    # Specific advanced/technical sensors not caught by the p13+ rule above
     advanced_keywords = [
         "gradient",
         "lowend",
@@ -162,6 +218,49 @@ def should_hide_entity_by_default(entity_name: str) -> bool:
 
     for keyword in advanced_keywords:
         if keyword in name_lower:
-            return True
+            return "advanced"
 
-    return False
+    return None
+
+
+def should_hide_entity_by_default(entity_name: str) -> bool:
+    """Determine if an entity should be hidden under the "default" visibility tier.
+
+    Kept for backward compatibility (equivalent to
+    ``should_hide_entity(entity_name, ENTITY_VISIBILITY_DEFAULT)``). Entities
+    are hidden if they:
+    - Are related to HC2 (heating circuit 2)
+    - Are time plan/program schedules
+    - Are advanced technical parameters that most users don't need
+
+    Args:
+        entity_name: The name of the entity to check.
+
+    Returns:
+        True if the entity should be hidden by default, False otherwise.
+    """
+    return _classify_hidden_category(entity_name) is not None
+
+
+def should_hide_entity(
+    entity_name: str, visibility: str = ENTITY_VISIBILITY_DEFAULT
+) -> bool:
+    """Determine if an entity should be hidden under the given visibility tier.
+
+    Args:
+        entity_name: The name of the entity to check.
+        visibility: One of the ``ENTITY_VISIBILITY_*`` values. Any
+            unrecognized value is treated as ``ENTITY_VISIBILITY_DEFAULT``.
+
+    Returns:
+        True if the entity should be hidden under this tier, False otherwise.
+    """
+    category = _classify_hidden_category(entity_name)
+    if category is None:
+        return False
+    if visibility == ENTITY_VISIBILITY_ALL:
+        return False
+    if visibility == ENTITY_VISIBILITY_EXTENDED:
+        return category == "schedule"
+    # "default" (or any unrecognized value) hides both categories.
+    return True

--- a/custom_components/thz/entity_id_style.py
+++ b/custom_components/thz/entity_id_style.py
@@ -1,0 +1,111 @@
+"""FHEM/technical-style entity_id slug generation.
+
+This module implements the "fhem" entity_id naming style (see
+``CONF_ENTITY_ID_STYLE`` in const.py). It converts a raw internal
+register-map/parameter name -- e.g. "dhwPump", "collectorTemp",
+"p01RoomTempDayHC1" -- into a lowercase, underscore-separated slug suitable
+for Home Assistant's ``suggested_object_id`` mechanism.
+
+Why this works without a hand-built name table: the vast majority of this
+integration's internal names were already ported verbatim from FHEM's own
+00_THZ.pm parsing tables (read side) or ARE the official Stiebel Eltron
+parameter identifiers (write side, e.g. "p01RoomTempDayHC1"). So producing
+an "FHEM-flavoured" entity_id mostly just means slugifying a name that is
+already FHEM's/Stiebel's own name -- no separate alias table is needed for
+these. (Short aliases like "PumpDHW" or "dhw_temp" seen in some FHEM user's
+own dashboard are *not* module-native names -- they come from that user's own
+``userReadings`` configuration in fhem.cfg, not from 00_THZ.pm itself, so
+they aren't a stable target to design against.)
+
+The slug algorithm deliberately uses a single, simple rule -- split only at a
+lowercase-or-digit-to-uppercase transition -- rather than a more "thorough"
+two-pass camelCase splitter. This keeps multi-letter runs like "STB", "HC1",
+"DHWset" glued together as one recognisable token instead of being split
+mid-acronym, which better matches how these names actually read in FHEM's
+own source and in Stiebel's documentation.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .const import ENTITY_ID_STYLE_FHEM
+
+# Matches the boundary between a lowercase letter/digit and an uppercase
+# letter, e.g. the "w|P" in "dhwPump" or the "1|R" in "p01RoomTempDayHC1".
+# Deliberately does NOT split runs of consecutive uppercase letters (e.g.
+# "STB", the "HC1"/"DHW" in "p01RoomTempDayHC1"/"p04DHWsetDayTemp") -- those
+# stay together as a single token.
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_INVALID_CHARS = re.compile(r"[^0-9a-zA-Z]+")
+_MULTI_UNDERSCORE = re.compile(r"_+")
+
+
+def fhem_style_object_id(raw_name: str) -> str:
+    """Convert a raw register-map/parameter name into an entity_id-safe slug.
+
+    Args:
+        raw_name: The internal name as it appears in a register-map tuple or
+            write-map entry (may have leading/trailing whitespace and/or a
+            trailing colon, e.g. " heatingCircuitPump: ").
+
+    Returns:
+        A lowercase slug containing only ``[a-z0-9_]``, with no leading,
+        trailing, or repeated underscores. Falls back to ``"thz_entity"`` for
+        a name that contains no alphanumeric characters at all (defensive;
+        should not happen with real register-map data).
+
+    Examples:
+        >>> fhem_style_object_id("dhwPump:")
+        'dhw_pump'
+        >>> fhem_style_object_id(" p01RoomTempDayHC1 ")
+        'p01_room_temp_day_hc1'
+        >>> fhem_style_object_id("STB")
+        'stb'
+        >>> fhem_style_object_id("p04DHWsetDayTemp")
+        'p04_dhwset_day_temp'
+    """
+    name = raw_name.strip().rstrip(":").strip()
+    name = _CAMEL_BOUNDARY.sub("_", name)
+    name = _INVALID_CHARS.sub("_", name)
+    name = name.lower()
+    name = _MULTI_UNDERSCORE.sub("_", name).strip("_")
+    return name or "thz_entity"
+
+
+def resolve_suggested_object_id(
+    raw_name: str,
+    entity_id_style: str,
+    device_prefix: str | None = None,
+) -> str | None:
+    """Return the HA ``suggested_object_id`` for the given naming style.
+
+    Args:
+        raw_name: The internal register-map/parameter name for this entity.
+        entity_id_style: One of the ``ENTITY_ID_STYLE_*`` values from const.py.
+        device_prefix: Optional device name/alias (e.g. the config flow's
+            "alias" field, such as "lwz") to prepend to the FHEM-style slug,
+            e.g. "lwz_p99start_unsched_vent" instead of bare
+            "p99start_unsched_vent". Slugified the same way as ``raw_name``.
+            Ignored (no prefix applied) if empty/None, or if it slugifies to
+            nothing usable. Has no effect for the default style.
+
+    Returns:
+        ``None`` for the default style (HA falls back to its own normal
+        name-derived entity_id, i.e. no override -- note this normal
+        fallback itself prepends the *full* device name for any entity with
+        ``has_entity_name=True``, per Home Assistant's own
+        ``Entity.suggested_object_id`` behavior), or the FHEM-style slug
+        (optionally device_prefix-prefixed) for :data:`ENTITY_ID_STYLE_FHEM`.
+        Note this only affects a brand-new entity's *first* entity_id
+        assignment -- it does not rename an entity that already exists in
+        the entity registry.
+    """
+    if entity_id_style != ENTITY_ID_STYLE_FHEM:
+        return None
+    slug = fhem_style_object_id(raw_name)
+    if device_prefix:
+        prefix_slug = fhem_style_object_id(device_prefix)
+        if prefix_slug and prefix_slug != "thz_entity":
+            return f"{prefix_slug}_{slug}"
+    return slug

--- a/custom_components/thz/number.py
+++ b/custom_components/thz/number.py
@@ -42,6 +42,9 @@ class THZNumber(THZBaseEntity, NumberEntity):
         device: THZDevice,
         device_id: str,
         scan_interval: int | None = None,
+        entity_id_style: str = "default",
+        entity_visibility: str = "default",
+        entity_id_prefix: str | None = None,
     ) -> None:
         """Initialize a THZ number entity.
 
@@ -51,6 +54,10 @@ class THZNumber(THZBaseEntity, NumberEntity):
             device: The device instance this entity belongs to.
             device_id: The device identifier for linking to device.
             scan_interval: The scan interval in seconds for polling updates.
+            entity_id_style: "default" or "fhem" (see base_entity.py).
+            entity_visibility: "default"/"extended"/"all" (see base_entity.py).
+            entity_id_prefix: Optional device alias prefix for "fhem"-style
+                entity_ids (see base_entity.py).
         """
         # Initialize base class with common properties
         super().__init__(
@@ -61,6 +68,10 @@ class THZNumber(THZBaseEntity, NumberEntity):
             icon=entry.get("icon"),
             scan_interval=scan_interval,
             translation_key=get_translation_key(name),
+            entity_id_style=entity_id_style,
+            entity_visibility=entity_visibility,
+            entity_id_prefix=entity_id_prefix,
+            domain="number",
         )
 
         # Number-specific attributes

--- a/custom_components/thz/platform_setup.py
+++ b/custom_components/thz/platform_setup.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Callable
 
-from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN
+from .const import (
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    ENTITY_ID_STYLE_DEFAULT,
+    ENTITY_VISIBILITY_DEFAULT,
+)
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -50,6 +55,9 @@ async def async_setup_write_platform(
     write_manager: RegisterMapManagerWrite = entry_data["write_manager"]
     device: THZDevice = entry_data["device"]
     device_id = entry_data["device_id"]
+    entity_id_style = entry_data.get("entity_id_style", ENTITY_ID_STYLE_DEFAULT)
+    entity_visibility = entry_data.get("entity_visibility", ENTITY_VISIBILITY_DEFAULT)
+    entity_id_prefix = entry_data.get("entity_id_prefix")
 
     # Get write interval from config, default to DEFAULT_UPDATE_INTERVAL
     write_interval = config_entry.data.get("write_interval", DEFAULT_UPDATE_INTERVAL)
@@ -85,6 +93,9 @@ async def async_setup_write_platform(
                     device=device,
                     device_id=device_id,
                     scan_interval=write_interval,
+                    entity_id_style=entity_id_style,
+                    entity_visibility=entity_visibility,
+                    entity_id_prefix=entity_id_prefix,
                 )
                 entities.append(entity)
 

--- a/custom_components/thz/register_maps/register_map_206.py
+++ b/custom_components/thz/register_maps/register_map_206.py
@@ -291,6 +291,14 @@ REGISTER_MAP = {
         (" diverterValve: ", 45, 1, "bit2", 1, {"icon": "mdi:valve", "translation_key": "diverter_valve"}),
         (" dhwPump: ", 45, 1, "bit1", 1, {"icon": "mdi:pump", "translation_key": "dhw_pump"}),
         (" heatingCircuitPump: ", 45, 1, "bit0", 1, {"icon": "mdi:pump", "translation_key": "heating_circuit_pump"}),
+        # solarPump: nibble 44 is fully claimed by compressor/boosterStage1-3
+        # below on firmware 2.06 -- FHEM's own FBglob206 table has the exact
+        # same "n.a" placeholder (note: no trailing dot, unlike the "n.a."
+        # used elsewhere -- a pre-existing typo in FHEM's own source, kept
+        # here for fidelity) here too, with no bit ever assigned. This is
+        # matching a known upstream limitation, not a bug in this port --
+        # there is no correct bit number to substitute without new
+        # hardware reverse-engineering.
         (" solarPump: ", 44, 1, "n.a", 1, {"icon": "mdi:weather-sunny", "translation_key": "solar_pump"}),
         (" compressor: ", 44, 1, "bit0", 1, {"icon": "mdi:engine", "translation_key": "compressor"}),
         (" boosterStage3: ", 44, 1, "bit3", 1, {"translation_key": "booster_stage_3"}),
@@ -300,6 +308,11 @@ REGISTER_MAP = {
         (" lowPressureSensor: ", 54, 1, "bit2", 1, {"translation_key": "low_pressure_sensor"}),
         (" evaporatorIceMonitor: ", 55, 1, "bit3", 1, {"translation_key": "evaporator_ice_monitor"}),
         (" signalAnode: ", 54, 1, "bit1", 1, {"translation_key": "signal_anode"}),
+        # evuRelease / STB: nibble 48 was repurposed on firmware 2.06 to carry
+        # outputVentilatorPower as a 2-nibble value instead of individual
+        # flag bits (see below). FHEM's own FBglob206 table marks both as
+        # "n.a." for exactly this reason -- matching a known upstream
+        # limitation, not a bug in this port.
         (" evuRelease: ", 48, 1, "n.a.", 1, {"translation_key": "evu_release"}),
         (" ovenFireplace: ", 54, 1, "bit0", 1, {"translation_key": "oven_fireplace"}),
         (" STB: ", 48, 1, "n.a.", 1, {"translation_key": "stb"}),

--- a/custom_components/thz/register_maps/register_map_214.py
+++ b/custom_components/thz/register_maps/register_map_214.py
@@ -93,12 +93,21 @@ REGISTER_MAP = {
         (" solarPump: ", 44, 1, "bit2", 1, {"icon": "mdi:weather-sunny", "translation_key": "solar_pump"}),
         (" compressor: ", 44, 1, "bit0", 1, {"icon": "mdi:engine", "translation_key": "compressor"}),
         (" boosterStage2: ", 44, 1, "bit3", 1, {"translation_key": "booster_stage_2"}),
+        # boosterStage3: nibble 44 is fully claimed by compressor/solarPump/
+        # boosterStage1-2 on firmware 2.14 -- FHEM's own FBglob214 table has
+        # the same "n.a." placeholder, with no bit ever assigned. Matches a
+        # known upstream limitation, not a bug in this port.
         (" boosterStage3: ", 44, 1, "n.a.", 1, {"translation_key": "booster_stage_3"}),
         (" boosterStage1: ", 44, 1, "bit1", 1, {"translation_key": "booster_stage_1"}),
         (" highPressureSensor: ", 54, 1, "bit3", 1, {"translation_key": "high_pressure_sensor"}),
         (" lowPressureSensor: ", 54, 1, "bit2", 1, {"translation_key": "low_pressure_sensor"}),
         (" evaporatorIceMonitor: ", 55, 1, "bit3", 1, {"translation_key": "evaporator_ice_monitor"}),
         (" signalAnode: ", 54, 1, "bit1", 1, {"translation_key": "signal_anode"}),
+        # evuRelease / STB: nibble 48 was repurposed on firmware 2.14 to carry
+        # outputVentilatorPower as a 2-nibble value instead of individual
+        # flag bits (see below). FHEM's own FBglob214 table marks both as
+        # "n.a." for exactly this reason -- matching a known upstream
+        # limitation, not a bug in this port.
         (" evuRelease: ", 48, 1, "n.a.", 1, {"translation_key": "evu_release"}),
         (" ovenFireplace: ", 54, 1, "bit0", 1, {"translation_key": "oven_fireplace"}),
         (" STB: ", 48, 1, "n.a.", 1, {"translation_key": "stb"}),

--- a/custom_components/thz/select.py
+++ b/custom_components/thz/select.py
@@ -45,6 +45,9 @@ class THZSelect(THZBaseEntity, SelectEntity):
         device: THZDevice,
         device_id: str,
         scan_interval: int | None = None,
+        entity_id_style: str = "default",
+        entity_visibility: str = "default",
+        entity_id_prefix: str | None = None,
     ) -> None:
         """Initialize a THZ select entity.
 
@@ -54,6 +57,10 @@ class THZSelect(THZBaseEntity, SelectEntity):
             device: The device instance this select entity belongs to.
             device_id: The device identifier for linking to device.
             scan_interval: The scan interval in seconds for polling updates.
+            entity_id_style: "default" or "fhem" (see base_entity.py).
+            entity_visibility: "default"/"extended"/"all" (see base_entity.py).
+            entity_id_prefix: Optional device alias prefix for "fhem"-style
+                entity_ids (see base_entity.py).
         """
         # Initialize base class with common properties
         super().__init__(
@@ -64,6 +71,10 @@ class THZSelect(THZBaseEntity, SelectEntity):
             icon=entry.get("icon"),
             scan_interval=scan_interval,
             translation_key=get_translation_key(name),
+            entity_id_style=entity_id_style,
+            entity_visibility=entity_visibility,
+            entity_id_prefix=entity_id_prefix,
+            domain="select",
         )
 
         # Select-specific attributes

--- a/custom_components/thz/sensor.py
+++ b/custom_components/thz/sensor.py
@@ -30,8 +30,14 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, should_hide_entity_by_default
+from .const import (
+    DOMAIN,
+    ENTITY_ID_STYLE_DEFAULT,
+    ENTITY_VISIBILITY_DEFAULT,
+    should_hide_entity,
+)
 from .cop_sensor import async_setup_cop_sensors
+from .entity_id_style import resolve_suggested_object_id
 from .register_maps.register_map_manager import RegisterMapManager
 from .value_codec import decode_raw_value
 
@@ -63,6 +69,9 @@ async def async_setup_entry(
     coordinators = entry_data["coordinators"]
     device_id = entry_data["device_id"]
     unsupported_blocks: set[str] = entry_data.get("unsupported_blocks", set())
+    entity_id_style = entry_data.get("entity_id_style", ENTITY_ID_STYLE_DEFAULT)
+    entity_visibility = entry_data.get("entity_visibility", ENTITY_VISIBILITY_DEFAULT)
+    entity_id_prefix = entry_data.get("entity_id_prefix")
 
     # Create sensors
     sensors = []
@@ -143,7 +152,13 @@ async def async_setup_entry(
             }
             sensors.append(
                 THZGenericSensor(
-                    coordinator, entry=entry, block=block_bytes, device_id=device_id
+                    coordinator,
+                    entry=entry,
+                    block=block_bytes,
+                    device_id=device_id,
+                    entity_id_style=entity_id_style,
+                    entity_visibility=entity_visibility,
+                    entity_id_prefix=entity_id_prefix,
                 )
             )
     async_add_entities(sensors, True)
@@ -248,7 +263,16 @@ class THZGenericSensor(CoordinatorEntity, SensorEntity):
         no translation is available.
     """
 
-    def __init__(self, coordinator, entry, block, device_id) -> None:
+    def __init__(
+        self,
+        coordinator,
+        entry,
+        block,
+        device_id,
+        entity_id_style=ENTITY_ID_STYLE_DEFAULT,
+        entity_visibility=ENTITY_VISIBILITY_DEFAULT,
+        entity_id_prefix=None,
+    ) -> None:
         """Initialize a sensor instance with the provided configuration.
 
         Args:
@@ -256,6 +280,11 @@ class THZGenericSensor(CoordinatorEntity, SensorEntity):
             entry: The configuration entry dict for the sensor.
             block: The block associated with the sensor.
             device_id: The unique device identifier.
+            entity_id_style: "default" or "fhem" (see entity_id_style.py).
+            entity_visibility: "default"/"extended"/"all" (see const.py's
+                should_hide_entity()).
+            entity_id_prefix: Optional device alias prefix for "fhem"-style
+                entity_ids (see entity_id_style.py).
 
         Note:
             When translation_key is available, only _attr_translation_key is set.
@@ -294,8 +323,21 @@ class THZGenericSensor(CoordinatorEntity, SensorEntity):
         # See base_entity.py for rationale on avoiding @property overrides
         # for entity_registry_enabled_default.
         self._attr_entity_registry_enabled_default = (
-            not should_hide_entity_by_default(self._entity_name)
+            not should_hide_entity(self._entity_name, entity_visibility)
         )
+
+        # Entity-ID naming style: independent of translation_key/unique_id.
+        # NOTE: Home Assistant has no "_attr_suggested_object_id" hook --
+        # Entity.suggested_object_id is a read-only @property, never backed by
+        # an "_attr_*" instance attribute. Setting self.entity_id directly
+        # (before this entity is added to hass) is the actually-supported way
+        # to seed a custom initial object_id -- see base_entity.py's
+        # THZBaseEntity.__init__ for the full explanation.
+        suggested_object_id = resolve_suggested_object_id(
+            self._entity_name, entity_id_style, device_prefix=entity_id_prefix
+        )
+        if suggested_object_id:
+            self.entity_id = f"sensor.{suggested_object_id}"
 
     @property
     def native_value(self) -> StateType | int | float | bool | str | None:

--- a/custom_components/thz/switch.py
+++ b/custom_components/thz/switch.py
@@ -45,6 +45,9 @@ class THZSwitch(THZBaseEntity, SwitchEntity):
         device: THZDevice,
         device_id: str,
         scan_interval: int | None = None,
+        entity_id_style: str = "default",
+        entity_visibility: str = "default",
+        entity_id_prefix: str | None = None,
     ) -> None:
         """Initialize a THZ switch entity.
 
@@ -54,6 +57,10 @@ class THZSwitch(THZBaseEntity, SwitchEntity):
             device: The device instance this switch is associated with.
             device_id: The device identifier for linking to device.
             scan_interval: The scan interval in seconds for polling updates.
+            entity_id_style: "default" or "fhem" (see base_entity.py).
+            entity_visibility: "default"/"extended"/"all" (see base_entity.py).
+            entity_id_prefix: Optional device alias prefix for "fhem"-style
+                entity_ids (see base_entity.py).
         """
         # Initialize base class with common properties
         super().__init__(
@@ -64,6 +71,10 @@ class THZSwitch(THZBaseEntity, SwitchEntity):
             icon=entry.get("icon"),
             scan_interval=scan_interval,
             translation_key=get_translation_key(name),
+            entity_id_style=entity_id_style,
+            entity_visibility=entity_visibility,
+            entity_id_prefix=entity_id_prefix,
+            domain="switch",
         )
 
         # Switch-specific attributes

--- a/custom_components/thz/time.py
+++ b/custom_components/thz/time.py
@@ -129,7 +129,16 @@ def quarters_to_time(num: int) -> time | None:
 
 
 
-def _create_time_entities(name, entry, device, device_id, write_interval):
+def _create_time_entities(
+    name,
+    entry,
+    device,
+    device_id,
+    write_interval,
+    entity_id_style="default",
+    entity_visibility="default",
+    entity_id_prefix=None,
+):
     """Factory function to create time entities, handling schedule types specially."""
     if entry["type"] == "schedule":
         # Create both start and end time entities for schedule type
@@ -143,6 +152,9 @@ def _create_time_entities(name, entry, device, device_id, write_interval):
                 device_id=device_id,
                 time_type="start",
                 scan_interval=write_interval,
+                entity_id_style=entity_id_style,
+                entity_visibility=entity_visibility,
+                entity_id_prefix=entity_id_prefix,
             ),
             THZScheduleTime(
                 name=f"{name} End",
@@ -152,6 +164,9 @@ def _create_time_entities(name, entry, device, device_id, write_interval):
                 device_id=device_id,
                 time_type="end",
                 scan_interval=write_interval,
+                entity_id_style=entity_id_style,
+                entity_visibility=entity_visibility,
+                entity_id_prefix=entity_id_prefix,
             ),
         ]
     else:
@@ -162,6 +177,9 @@ def _create_time_entities(name, entry, device, device_id, write_interval):
             device=device,
             device_id=device_id,
             scan_interval=write_interval,
+            entity_id_style=entity_id_style,
+            entity_visibility=entity_visibility,
+            entity_id_prefix=entity_id_prefix,
         )
 
 
@@ -176,6 +194,9 @@ async def async_setup_entry(
     write_manager: RegisterMapManagerWrite = entry_data["write_manager"]
     device: THZDevice = entry_data["device"]
     device_id = entry_data["device_id"]
+    entity_id_style = entry_data.get("entity_id_style", "default")
+    entity_visibility = entry_data.get("entity_visibility", "default")
+    entity_id_prefix = entry_data.get("entity_id_prefix")
 
     from .const import DEFAULT_UPDATE_INTERVAL
     write_interval = config_entry.data.get("write_interval", DEFAULT_UPDATE_INTERVAL)
@@ -191,7 +212,14 @@ async def async_setup_entry(
                 name, entry["type"], entry["command"]
             )
             new_entities = _create_time_entities(
-                name, entry, device, device_id, write_interval
+                name,
+                entry,
+                device,
+                device_id,
+                write_interval,
+                entity_id_style,
+                entity_visibility,
+                entity_id_prefix,
             )
             entities.extend(
                 new_entities if isinstance(new_entities, list) else [new_entities]
@@ -212,7 +240,10 @@ class THZTime(THZBaseEntity, TimeEntity):
         entry: dict,
         device: THZDevice,
         device_id: str,
-        scan_interval: int | None = None
+        scan_interval: int | None = None,
+        entity_id_style: str = "default",
+        entity_visibility: str = "default",
+        entity_id_prefix: str | None = None,
     ) -> None:
         """Initialize a THZ time entity.
 
@@ -222,6 +253,10 @@ class THZTime(THZBaseEntity, TimeEntity):
             device: THZ device instance.
             device_id: The device identifier for linking to device.
             scan_interval: The scan interval in seconds for polling updates.
+            entity_id_style: "default" or "fhem" (see base_entity.py).
+            entity_visibility: "default"/"extended"/"all" (see base_entity.py).
+            entity_id_prefix: Optional device alias prefix for "fhem"-style
+                entity_ids (see base_entity.py).
         """
         # Initialize base class with common properties
         super().__init__(
@@ -232,6 +267,10 @@ class THZTime(THZBaseEntity, TimeEntity):
             icon=entry.get("icon", "mdi:clock"),
             scan_interval=scan_interval,
             translation_key=get_translation_key(name),
+            entity_id_style=entity_id_style,
+            entity_visibility=entity_visibility,
+            entity_id_prefix=entity_id_prefix,
+            domain="time",
         )
 
         # Explicitly enable has_entity_name for time entities
@@ -313,7 +352,10 @@ class THZScheduleTime(THZBaseEntity, TimeEntity):
         device: THZDevice,
         device_id: str,
         time_type: str,
-        scan_interval: int | None = None
+        scan_interval: int | None = None,
+        entity_id_style: str = "default",
+        entity_visibility: str = "default",
+        entity_id_prefix: str | None = None,
     ) -> None:
         """Initialize a THZ schedule time entity.
 
@@ -328,6 +370,13 @@ class THZScheduleTime(THZBaseEntity, TimeEntity):
             device_id: The device identifier for linking to device.
             time_type: Either "start" or "end".
             scan_interval: The scan interval in seconds for polling updates.
+            entity_id_style: "default" or "fhem" (see base_entity.py). Applied
+                using the full ``name`` (already including the " Start"/" End"
+                suffix), so the FHEM-style entity_id naturally ends in
+                "_start"/"_end" too.
+            entity_visibility: "default"/"extended"/"all" (see base_entity.py).
+            entity_id_prefix: Optional device alias prefix for "fhem"-style
+                entity_ids (see base_entity.py).
 
         Example:
             For base_name="programHC1_Mo_0" and time_type="start", the translation key
@@ -350,6 +399,10 @@ class THZScheduleTime(THZBaseEntity, TimeEntity):
             icon=entry.get("icon", "mdi:calendar-clock"),
             scan_interval=scan_interval,
             translation_key=translation_key,
+            entity_id_style=entity_id_style,
+            entity_visibility=entity_visibility,
+            entity_id_prefix=entity_id_prefix,
+            domain="time",
         )
 
         # Explicitly enable has_entity_name for time entities

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,13 @@ class MockEntity:
     integration's entity classes.
     """
 
+    # Real HA's Entity class defines this as a class attribute defaulting to
+    # None (only set once the entity is actually added to hass, or earlier by
+    # the entity itself to suggest an object_id -- see base_entity.py's
+    # THZBaseEntity.__init__). Mirrored here so tests can assert on it the
+    # same way they would against the real Entity class.
+    entity_id: str | None = None
+
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return entity_registry_enabled_default via HA's _attr_ pattern."""

--- a/tests/test_cleanup_orphaned_entities.py
+++ b/tests/test_cleanup_orphaned_entities.py
@@ -1,0 +1,124 @@
+"""Tests for _async_cleanup_orphaned_entities.
+
+Regression coverage for a real-world bug: an entity registry row survives
+"Delete integration" -> re-add cycles because Home Assistant leaves its
+config_entry_id pointing at the now-deleted entry's id instead of nulling it
+out. The original cleanup only checked for config_entry_id is None, so it
+never caught this -- the stale row (and its unique_id) got silently
+reattached on every subsequent setup, permanently freezing that entity's
+entity_id to whatever it was the very first time it was ever created,
+regardless of any later entity_id_style/alias changes.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.thz import _async_cleanup_orphaned_entities, er
+
+
+def _make_entity(entity_id, platform, config_entry_id):
+    entity = MagicMock()
+    entity.entity_id = entity_id
+    entity.platform = platform
+    entity.config_entry_id = config_entry_id
+    return entity
+
+
+class TestCleanupOrphanedEntities:
+    @pytest.mark.asyncio
+    async def test_removes_entity_with_none_config_entry_id(self):
+        """Original behavior: config_entry_id is None -> removed."""
+        entity = _make_entity("number.thz_foo", "thz", None)
+        registry = MagicMock()
+        registry.entities.values.return_value = [entity]
+        hass = MagicMock()
+        hass.config_entries.async_get_entry.return_value = MagicMock()
+
+        with patch.object(
+            er, "async_get", return_value=registry
+        ):
+            await _async_cleanup_orphaned_entities(hass)
+
+        registry.async_remove.assert_called_once_with("number.thz_foo")
+
+    @pytest.mark.asyncio
+    async def test_removes_entity_with_dangling_config_entry_id(self):
+        """Regression: config_entry_id points at a deleted entry -> removed.
+
+        This is the case the original None-only check missed -- Home
+        Assistant left config_entry_id set to the old entry's id rather than
+        nulling it, so the entity looked "owned" and was never cleaned up.
+        """
+        entity = _make_entity("number.thz_stale", "thz", "deleted_entry_id")
+        registry = MagicMock()
+        registry.entities.values.return_value = [entity]
+        hass = MagicMock()
+        # No config entry exists with this id anymore.
+        hass.config_entries.async_get_entry.return_value = None
+
+        with patch.object(
+            er, "async_get", return_value=registry
+        ):
+            await _async_cleanup_orphaned_entities(hass)
+
+        registry.async_remove.assert_called_once_with("number.thz_stale")
+        hass.config_entries.async_get_entry.assert_called_once_with(
+            "deleted_entry_id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_keeps_entity_with_valid_config_entry_id(self):
+        """An entity whose config_entry_id refers to a real, live entry is
+        left alone."""
+        entity = _make_entity("number.thz_live", "thz", "live_entry_id")
+        registry = MagicMock()
+        registry.entities.values.return_value = [entity]
+        hass = MagicMock()
+        hass.config_entries.async_get_entry.return_value = MagicMock()  # exists
+
+        with patch.object(
+            er, "async_get", return_value=registry
+        ):
+            await _async_cleanup_orphaned_entities(hass)
+
+        registry.async_remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ignores_entities_from_other_platforms(self):
+        """An orphaned-looking entity from a different platform is never
+        touched, even with a dangling config_entry_id."""
+        entity = _make_entity("sensor.other_thing", "some_other_platform", None)
+        registry = MagicMock()
+        registry.entities.values.return_value = [entity]
+        hass = MagicMock()
+        hass.config_entries.async_get_entry.return_value = None
+
+        with patch.object(
+            er, "async_get", return_value=registry
+        ):
+            await _async_cleanup_orphaned_entities(hass)
+
+        registry.async_remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mixed_batch_removes_only_orphaned_thz_entities(self):
+        """A realistic mixed batch: live thz entity kept, dangling thz
+        entity removed, non-thz entity untouched."""
+        live = _make_entity("number.thz_live", "thz", "live_entry_id")
+        stale = _make_entity("number.thz_stale", "thz", "deleted_entry_id")
+        other = _make_entity("sensor.other", "voip", None)
+        registry = MagicMock()
+        registry.entities.values.return_value = [live, stale, other]
+        hass = MagicMock()
+
+        def fake_get_entry(entry_id):
+            return MagicMock() if entry_id == "live_entry_id" else None
+
+        hass.config_entries.async_get_entry.side_effect = fake_get_entry
+
+        with patch.object(
+            er, "async_get", return_value=registry
+        ):
+            await _async_cleanup_orphaned_entities(hass)
+
+        registry.async_remove.assert_called_once_with("number.thz_stale")

--- a/tests/test_config_flow_ports.py
+++ b/tests/test_config_flow_ports.py
@@ -312,3 +312,394 @@ class TestListSerialPorts:
         assert result["/dev/ttyUSB0"] == "/dev/ttyUSB0"
 
 
+class TestEntityIdStyleOption:
+    """Tests for the entity_id_style config-flow option (FHEM-style entity_id)."""
+
+    def test_init_defaults_to_default_style(self):
+        from custom_components.thz.const import ENTITY_ID_STYLE_DEFAULT
+
+        flow = THZConfigFlow()
+        assert flow.entity_id_style == ENTITY_ID_STYLE_DEFAULT
+
+    def test_async_step_user_schema_includes_entity_id_style(self):
+        """The very first setup step's schema offers the entity_id_style field.
+
+        NOTE: voluptuous is globally mocked in conftest.py for this whole test
+        suite (vol.Schema(...) returns a fresh MagicMock regardless of the
+        dict passed in), so we can't inspect the resulting vol.Schema object
+        itself. Instead we inspect the mocked vol.Optional/vol.Required
+        constructor's call args -- config_flow.py always calls
+        vol.Optional(CONF_ENTITY_ID_STYLE, ...) to add this field, so its
+        presence there is a reliable signal the field was actually added to
+        schema_dict.
+        """
+        import asyncio
+        import voluptuous as vol
+        from custom_components.thz.const import CONF_ENTITY_ID_STYLE
+
+        vol.Optional.reset_mock()
+        flow = THZConfigFlow()
+        flow.async_show_form = MagicMock(side_effect=lambda **kw: kw)
+        asyncio.run(flow.async_step_user(None))
+
+        assert any(
+            call.args and call.args[0] == CONF_ENTITY_ID_STYLE
+            for call in vol.Optional.call_args_list
+        )
+
+    def test_async_step_user_captures_entity_id_style_and_routes_to_usb(self):
+        import asyncio
+        from custom_components.thz.const import CONNECTION_USB
+
+        flow = THZConfigFlow()
+
+        async def fake_setup_usb():
+            return "usb_step"
+
+        flow.async_step_setup_usb = fake_setup_usb
+
+        result = asyncio.run(
+            flow.async_step_user(
+                {"connection_type": CONNECTION_USB, "entity_id_style": "fhem"}
+            )
+        )
+        assert flow.entity_id_style == "fhem"
+        assert result == "usb_step"
+
+    def test_async_step_user_defaults_entity_id_style_when_omitted(self):
+        """If the form is somehow submitted without the field, fall back safely."""
+        import asyncio
+        from custom_components.thz.const import CONNECTION_USB, ENTITY_ID_STYLE_DEFAULT
+
+        flow = THZConfigFlow()
+
+        async def fake_setup_usb():
+            return "usb_step"
+
+        flow.async_step_setup_usb = fake_setup_usb
+
+        asyncio.run(flow.async_step_user({"connection_type": CONNECTION_USB}))
+        assert flow.entity_id_style == ENTITY_ID_STYLE_DEFAULT
+
+    def test_reconfigure_schema_includes_entity_id_style(self):
+        """reconfigure_schema() exposes the same option for later changes.
+
+        See the note on test_async_step_user_schema_includes_entity_id_style
+        for why this inspects the mocked vol.Optional constructor's call args
+        rather than the (also mocked) resulting vol.Schema object.
+        """
+        import asyncio
+        import voluptuous as vol
+        from custom_components.thz.const import (
+            CONF_CONNECTION_TYPE,
+            CONF_ENTITY_ID_STYLE,
+            CONNECTION_IP,
+        )
+
+        flow = THZConfigFlow()
+        flow.hass = MagicMock()
+
+        fake_area_registry = MagicMock()
+        fake_area_registry.async_list_areas.return_value = []
+
+        vol.Optional.reset_mock()
+        with patch(
+            "custom_components.thz.config_flow.ar.async_get",
+            return_value=fake_area_registry,
+        ):
+            asyncio.run(flow.reconfigure_schema({CONF_CONNECTION_TYPE: CONNECTION_IP}))
+
+        assert any(
+            call.args and call.args[0] == CONF_ENTITY_ID_STYLE
+            for call in vol.Optional.call_args_list
+        )
+
+    def test_reconfigure_schema_preserves_existing_entity_id_style_default(self):
+        """A stored 'fhem' choice is prefilled as the form's default, not reset."""
+        import asyncio
+        import voluptuous as vol
+        from custom_components.thz.const import (
+            CONF_CONNECTION_TYPE,
+            CONF_ENTITY_ID_STYLE,
+            CONNECTION_IP,
+        )
+
+        flow = THZConfigFlow()
+        flow.hass = MagicMock()
+
+        fake_area_registry = MagicMock()
+        fake_area_registry.async_list_areas.return_value = []
+
+        vol.Optional.reset_mock()
+        with patch(
+            "custom_components.thz.config_flow.ar.async_get",
+            return_value=fake_area_registry,
+        ):
+            asyncio.run(
+                flow.reconfigure_schema(
+                    {CONF_CONNECTION_TYPE: CONNECTION_IP, CONF_ENTITY_ID_STYLE: "fhem"}
+                )
+            )
+
+        matching_calls = [
+            call
+            for call in vol.Optional.call_args_list
+            if call.args and call.args[0] == CONF_ENTITY_ID_STYLE
+        ]
+        assert matching_calls, "vol.Optional was never called for entity_id_style"
+        assert matching_calls[-1].kwargs.get("default") == "fhem"
+
+
+class TestEntityVisibilityOption:
+    """Tests for the entity_visibility config-flow option (default/extended/all)."""
+
+    def test_init_defaults_to_default_visibility(self):
+        from custom_components.thz.const import ENTITY_VISIBILITY_DEFAULT
+
+        flow = THZConfigFlow()
+        assert flow.entity_visibility == ENTITY_VISIBILITY_DEFAULT
+
+    def test_async_step_user_schema_includes_entity_visibility(self):
+        """The very first setup step's schema offers the entity_visibility field.
+
+        See the note on TestEntityIdStyleOption's schema test for why this
+        inspects the mocked vol.Optional constructor's call args rather than
+        the (also mocked) resulting vol.Schema object.
+        """
+        import asyncio
+        import voluptuous as vol
+        from custom_components.thz.const import CONF_ENTITY_VISIBILITY
+
+        vol.Optional.reset_mock()
+        flow = THZConfigFlow()
+        flow.async_show_form = MagicMock(side_effect=lambda **kw: kw)
+        asyncio.run(flow.async_step_user(None))
+
+        assert any(
+            call.args and call.args[0] == CONF_ENTITY_VISIBILITY
+            for call in vol.Optional.call_args_list
+        )
+
+    def test_async_step_user_captures_entity_visibility_and_routes_to_usb(self):
+        import asyncio
+        from custom_components.thz.const import CONNECTION_USB
+
+        flow = THZConfigFlow()
+
+        async def fake_setup_usb():
+            return "usb_step"
+
+        flow.async_step_setup_usb = fake_setup_usb
+
+        result = asyncio.run(
+            flow.async_step_user(
+                {"connection_type": CONNECTION_USB, "entity_visibility": "extended"}
+            )
+        )
+        assert flow.entity_visibility == "extended"
+        assert result == "usb_step"
+
+    def test_async_step_user_defaults_entity_visibility_when_omitted(self):
+        """If the form is somehow submitted without the field, fall back safely."""
+        import asyncio
+        from custom_components.thz.const import (
+            CONNECTION_USB,
+            ENTITY_VISIBILITY_DEFAULT,
+        )
+
+        flow = THZConfigFlow()
+
+        async def fake_setup_usb():
+            return "usb_step"
+
+        flow.async_step_setup_usb = fake_setup_usb
+
+        asyncio.run(flow.async_step_user({"connection_type": CONNECTION_USB}))
+        assert flow.entity_visibility == ENTITY_VISIBILITY_DEFAULT
+
+    def test_reconfigure_schema_includes_entity_visibility(self):
+        """reconfigure_schema() exposes the same option for later changes.
+
+        This is the field that lets the user retroactively apply a different
+        visibility tier to an existing install (see
+        _async_apply_entity_visibility_tier in __init__.py).
+        """
+        import asyncio
+        import voluptuous as vol
+        from custom_components.thz.const import (
+            CONF_CONNECTION_TYPE,
+            CONF_ENTITY_VISIBILITY,
+            CONNECTION_IP,
+        )
+
+        flow = THZConfigFlow()
+        flow.hass = MagicMock()
+
+        fake_area_registry = MagicMock()
+        fake_area_registry.async_list_areas.return_value = []
+
+        vol.Optional.reset_mock()
+        with patch(
+            "custom_components.thz.config_flow.ar.async_get",
+            return_value=fake_area_registry,
+        ):
+            asyncio.run(flow.reconfigure_schema({CONF_CONNECTION_TYPE: CONNECTION_IP}))
+
+        assert any(
+            call.args and call.args[0] == CONF_ENTITY_VISIBILITY
+            for call in vol.Optional.call_args_list
+        )
+
+    def test_reconfigure_schema_preserves_existing_entity_visibility_default(self):
+        """A stored 'all' choice is prefilled as the form's default, not reset."""
+        import asyncio
+        import voluptuous as vol
+        from custom_components.thz.const import (
+            CONF_CONNECTION_TYPE,
+            CONF_ENTITY_VISIBILITY,
+            CONNECTION_IP,
+        )
+
+        flow = THZConfigFlow()
+        flow.hass = MagicMock()
+
+        fake_area_registry = MagicMock()
+        fake_area_registry.async_list_areas.return_value = []
+
+        vol.Optional.reset_mock()
+        with patch(
+            "custom_components.thz.config_flow.ar.async_get",
+            return_value=fake_area_registry,
+        ):
+            asyncio.run(
+                flow.reconfigure_schema(
+                    {CONF_CONNECTION_TYPE: CONNECTION_IP, CONF_ENTITY_VISIBILITY: "all"}
+                )
+            )
+
+        matching_calls = [
+            call
+            for call in vol.Optional.call_args_list
+            if call.args and call.args[0] == CONF_ENTITY_VISIBILITY
+        ]
+        assert matching_calls, "vol.Optional was never called for entity_visibility"
+        assert matching_calls[-1].kwargs.get("default") == "all"
+
+    def test_refresh_blocks_final_data_includes_entity_visibility(self):
+        """The final config-entry data dict carries the chosen visibility tier."""
+        import asyncio
+        from custom_components.thz.const import (
+            CONF_ENTITY_VISIBILITY,
+            DEFAULT_UPDATE_INTERVAL,
+        )
+
+        flow = THZConfigFlow()
+        flow.connection_data = {"connection_type": "ip", "host": "1.2.3.4"}
+        flow.blocks = []
+        flow.entity_visibility = "extended"
+
+        captured = {}
+
+        def fake_create_entry(title, data):
+            captured["data"] = data
+            return {"title": title, "data": data}
+
+        flow.async_create_entry = fake_create_entry
+
+        asyncio.run(
+            flow.async_step_refresh_blocks(
+                {"write_interval": DEFAULT_UPDATE_INTERVAL}
+            )
+        )
+
+        assert captured["data"][CONF_ENTITY_VISIBILITY] == "extended"
+
+
+class TestAliasOption:
+    """Tests for the "alias" field exposed in the initial setup flow.
+
+    "alias" is the short device name (e.g. "lwz") used both as the HA device
+    name and -- when entity_id_style is "fhem" -- as the entity_id prefix
+    (see entity_id_style.resolve_suggested_object_id). It was previously only
+    settable via Reconfigure; this covers it also being settable up front.
+    """
+
+    def test_init_defaults_to_empty_alias(self):
+        flow = THZConfigFlow()
+        assert flow.alias == ""
+
+    def test_async_step_user_schema_includes_alias(self):
+        """The very first setup step's schema offers the alias field."""
+        import asyncio
+        import voluptuous as vol
+
+        vol.Optional.reset_mock()
+        flow = THZConfigFlow()
+        flow.async_show_form = MagicMock(side_effect=lambda **kw: kw)
+        asyncio.run(flow.async_step_user(None))
+
+        assert any(
+            call.args and call.args[0] == "alias"
+            for call in vol.Optional.call_args_list
+        )
+
+    def test_async_step_user_captures_alias_and_strips_whitespace(self):
+        import asyncio
+        from custom_components.thz.const import CONNECTION_USB
+
+        flow = THZConfigFlow()
+
+        async def fake_setup_usb():
+            return "usb_step"
+
+        flow.async_step_setup_usb = fake_setup_usb
+
+        result = asyncio.run(
+            flow.async_step_user(
+                {"connection_type": CONNECTION_USB, "alias": "  lwz  "}
+            )
+        )
+        assert flow.alias == "lwz"
+        assert result == "usb_step"
+
+    def test_async_step_user_defaults_alias_to_empty_when_omitted(self):
+        import asyncio
+        from custom_components.thz.const import CONNECTION_USB
+
+        flow = THZConfigFlow()
+
+        async def fake_setup_usb():
+            return "usb_step"
+
+        flow.async_step_setup_usb = fake_setup_usb
+
+        asyncio.run(flow.async_step_user({"connection_type": CONNECTION_USB}))
+        assert flow.alias == ""
+
+    def test_refresh_blocks_final_data_includes_alias(self):
+        """The final config-entry data dict carries the chosen alias."""
+        import asyncio
+        from custom_components.thz.const import DEFAULT_UPDATE_INTERVAL
+
+        flow = THZConfigFlow()
+        flow.connection_data = {"connection_type": "ip", "host": "1.2.3.4"}
+        flow.blocks = []
+        flow.alias = "lwz"
+
+        captured = {}
+
+        def fake_create_entry(title, data):
+            captured["data"] = data
+            return {"title": title, "data": data}
+
+        flow.async_create_entry = fake_create_entry
+
+        asyncio.run(
+            flow.async_step_refresh_blocks(
+                {"write_interval": DEFAULT_UPDATE_INTERVAL}
+            )
+        )
+
+        assert captured["data"]["alias"] == "lwz"
+
+

--- a/tests/test_entity_id_style.py
+++ b/tests/test_entity_id_style.py
@@ -1,0 +1,133 @@
+"""Tests for the FHEM/technical entity_id naming style.
+
+Covers fhem_style_object_id()'s slugification of raw register-map/parameter
+names, and resolve_suggested_object_id()'s style gating.
+"""
+import pytest
+
+from custom_components.thz.entity_id_style import (
+    fhem_style_object_id,
+    resolve_suggested_object_id,
+)
+
+
+class TestFhemStyleObjectId:
+    """Structural slugification tests."""
+
+    @pytest.mark.parametrize(
+        "raw_name,expected",
+        [
+            ("dhwPump", "dhw_pump"),
+            ("dhwPump:", "dhw_pump"),
+            (" heatingCircuitPump: ", "heating_circuit_pump"),
+            ("solarPump", "solar_pump"),
+            ("compressor", "compressor"),
+            ("boosterStage1", "booster_stage1"),
+            ("boosterStage3", "booster_stage3"),
+            ("collectorTemp", "collector_temp"),
+            ("outsideTemp", "outside_temp"),
+            ("insideTempRC", "inside_temp_rc"),
+            ("outputVentilatorSpeed", "output_ventilator_speed"),
+            ("p01RoomTempDayHC1", "p01_room_temp_day_hc1"),
+            ("p04DHWsetDayTemp", "p04_dhwset_day_temp"),
+            ("p99startUnschedVent", "p99start_unsched_vent"),
+            ("STB", "stb"),
+            ("relHumidity", "rel_humidity"),
+            ("evuRelease", "evu_release"),
+        ],
+    )
+    def test_slug_matches_expected(self, raw_name, expected):
+        assert fhem_style_object_id(raw_name) == expected
+
+    def test_strips_whitespace_and_colon(self):
+        assert fhem_style_object_id("  dhwTemp:  ") == "dhw_temp"
+
+    def test_collapses_invalid_characters(self):
+        assert fhem_style_object_id("out (raw)") == "out_raw"
+
+    def test_no_leading_or_trailing_underscore(self):
+        slug = fhem_style_object_id(":: solarPump ::")
+        assert not slug.startswith("_")
+        assert not slug.endswith("_")
+
+    def test_fallback_for_empty_name(self):
+        assert fhem_style_object_id("::: ") == "thz_entity"
+
+    def test_deterministic(self):
+        """Same input always produces the same slug."""
+        assert fhem_style_object_id("dhwPump") == fhem_style_object_id("dhwPump")
+
+
+class TestResolveSuggestedObjectId:
+    """Style-gating tests."""
+
+    def test_default_style_returns_none(self):
+        assert resolve_suggested_object_id("dhwPump", "default") is None
+
+    def test_unknown_style_returns_none(self):
+        assert resolve_suggested_object_id("dhwPump", "something_else") is None
+
+    def test_fhem_style_returns_slug(self):
+        assert resolve_suggested_object_id("dhwPump:", "fhem") == "dhw_pump"
+
+    def test_fhem_style_matches_direct_slug_call(self):
+        name = "p01RoomTempDayHC1"
+        assert resolve_suggested_object_id(name, "fhem") == fhem_style_object_id(name)
+
+
+class TestDevicePrefix:
+    """Tests for the optional device_prefix argument (short device alias).
+
+    This lets a user set a short device name/alias (e.g. "lwz") that gets
+    prepended to the FHEM-style slug, e.g. "lwz_p99start_unsched_vent",
+    instead of relying on Home Assistant's own has_entity_name fallback
+    (which prepends the FULL device name/alias and only kicks in for the
+    "default" style, where suggested_object_id is left unset entirely).
+    """
+
+    def test_fhem_style_with_prefix(self):
+        assert (
+            resolve_suggested_object_id(
+                "p99startUnschedVent", "fhem", device_prefix="lwz"
+            )
+            == "lwz_p99start_unsched_vent"
+        )
+
+    def test_prefix_is_slugified_same_as_raw_name(self):
+        """A verbose alias is slugified the same way as any raw name."""
+        assert (
+            resolve_suggested_object_id(
+                "dhwPump", "fhem", device_prefix="Heating Clima Water Control LWZ"
+            )
+            == "heating_clima_water_control_lwz_dhw_pump"
+        )
+
+    def test_no_prefix_when_none(self):
+        assert (
+            resolve_suggested_object_id("dhwPump", "fhem", device_prefix=None)
+            == "dhw_pump"
+        )
+
+    def test_no_prefix_when_empty_string(self):
+        assert (
+            resolve_suggested_object_id("dhwPump", "fhem", device_prefix="")
+            == "dhw_pump"
+        )
+
+    def test_no_prefix_when_prefix_has_no_alnum_chars(self):
+        """A prefix that slugifies to nothing usable is dropped, not glued on."""
+        assert (
+            resolve_suggested_object_id("dhwPump", "fhem", device_prefix=":::")
+            == "dhw_pump"
+        )
+
+    def test_prefix_ignored_for_default_style(self):
+        """device_prefix has no effect outside the fhem style."""
+        assert (
+            resolve_suggested_object_id("dhwPump", "default", device_prefix="lwz")
+            is None
+        )
+
+    def test_prefix_is_positional_keyword_only_by_convention(self):
+        """Backward compatible: callers that omit device_prefix still work."""
+        assert resolve_suggested_object_id("dhwPump", "fhem") == "dhw_pump"

--- a/tests/test_entity_id_style_integration.py
+++ b/tests/test_entity_id_style_integration.py
@@ -1,0 +1,568 @@
+"""Integration tests: entity_id_style threads through to self.entity_id.
+
+Verifies the full path from each platform's entity class -> THZBaseEntity /
+THZGenericSensor / THZBinarySensor -> entity_id_style.resolve_suggested_object_id(),
+for both the write-entity platforms (number/switch/select/time) and the
+read-entity platforms (sensor/binary_sensor).
+
+These assert on ``entity.entity_id`` rather than ``entity._attr_suggested_object_id``:
+Home Assistant's real ``Entity.suggested_object_id`` is a read-only @property
+computed from name/translations and never consults any "_attr_*" instance
+attribute, so setting one is a silent no-op against the real entity_platform
+pipeline. Setting ``self.entity_id`` directly (what the production code now
+does) is the mechanism entity_platform.py actually honors -- see
+base_entity.py's THZBaseEntity.__init__.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.thz.entity_id_style import fhem_style_object_id
+
+
+def _make_mock_device():
+    device = MagicMock()
+    device.lock = MagicMock()
+    return device
+
+
+class TestWriteEntityIdStyle:
+    """number/switch/select/time entities honour entity_id_style."""
+
+    def test_switch_default_style_leaves_suggested_object_id_unset(self):
+        from custom_components.thz.switch import THZSwitch
+
+        entity = THZSwitch(
+            name="zPumpHC",
+            entry={"command": "0A0052", "type": "switch", "icon": ""},
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="default",
+        )
+        assert entity.entity_id is None
+
+    def test_switch_fhem_style_sets_suggested_object_id(self):
+        from custom_components.thz.switch import THZSwitch
+
+        entity = THZSwitch(
+            name="zPumpHC",
+            entry={"command": "0A0052", "type": "switch", "icon": ""},
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="fhem",
+        )
+        assert entity.entity_id == f"switch.{fhem_style_object_id('zPumpHC')}"
+
+    def test_number_fhem_style_sets_suggested_object_id(self):
+        from custom_components.thz.number import THZNumber
+
+        entity = THZNumber(
+            name="p01RoomTempDayHC1",
+            entry={
+                "command": "0A0800",
+                "type": "number",
+                "icon": "",
+                "min": 0,
+                "max": 100,
+                "step": 1,
+                "unit": "",
+                "device_class": "",
+                "decode_type": "0clean",
+            },
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="fhem",
+        )
+        assert entity.entity_id == "number.p01_room_temp_day_hc1"
+
+    def test_select_fhem_style_sets_suggested_object_id(self):
+        from custom_components.thz.select import THZSelect
+
+        entity = THZSelect(
+            name="pOpMode",
+            entry={"command": "0A0900", "type": "select", "icon": "", "decode_type": "opmode"},
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="fhem",
+        )
+        assert entity.entity_id == "select.p_op_mode"
+
+    def test_time_fhem_style_sets_suggested_object_id(self):
+        from custom_components.thz.time import THZTime
+
+        entity = THZTime(
+            name="pHolidayBeginTime",
+            entry={"command": "0A0600", "type": "time", "icon": "mdi:clock"},
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="fhem",
+        )
+        assert entity.entity_id == f"time.{fhem_style_object_id('pHolidayBeginTime')}"
+
+    def test_schedule_time_fhem_style_includes_start_end_suffix(self):
+        from custom_components.thz.time import THZScheduleTime
+
+        entry = {"command": "0A0500", "type": "schedule", "icon": "mdi:calendar-clock"}
+        start_entity = THZScheduleTime(
+            name="programHC1_Mo_0 Start",
+            base_name="programHC1_Mo_0",
+            entry=entry,
+            device=_make_mock_device(),
+            device_id="test_device",
+            time_type="start",
+            entity_id_style="fhem",
+        )
+        end_entity = THZScheduleTime(
+            name="programHC1_Mo_0 End",
+            base_name="programHC1_Mo_0",
+            entry=entry,
+            device=_make_mock_device(),
+            device_id="test_device",
+            time_type="end",
+            entity_id_style="fhem",
+        )
+        assert start_entity.entity_id == "time.program_hc1_mo_0_start"
+        assert end_entity.entity_id == "time.program_hc1_mo_0_end"
+
+    def test_default_entity_id_style_is_backward_compatible(self):
+        """Omitting entity_id_style entirely still works (defaults to "default")."""
+        from custom_components.thz.switch import THZSwitch
+
+        entity = THZSwitch(
+            name="zPumpHC",
+            entry={"command": "0A0052", "type": "switch", "icon": ""},
+            device=_make_mock_device(),
+            device_id="test_device",
+        )
+        assert entity.entity_id is None
+
+    def test_button_fhem_style_sets_suggested_object_id(self):
+        from custom_components.thz.button import THZButton
+
+        entity = THZButton(
+            name="zResetLast10errors",
+            entry={"command": "0A0700", "type": "button", "icon": ""},
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="fhem",
+        )
+        assert entity.entity_id == f"button.{fhem_style_object_id('zResetLast10errors')}"
+
+    def test_button_default_style_leaves_suggested_object_id_unset(self):
+        from custom_components.thz.button import THZButton
+
+        entity = THZButton(
+            name="zResetLast10errors",
+            entry={"command": "0A0700", "type": "button", "icon": ""},
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="default",
+        )
+        assert entity.entity_id is None
+
+
+class TestClimateEntityIdStyle:
+    """THZClimate honours entity_id_style too.
+
+    THZClimate doesn't inherit THZBaseEntity (it's built directly on
+    CoordinatorEntity/ClimateEntity), and was missed entirely when this
+    feature was first added -- it had no entity_id_style/entity_id_prefix
+    parameters at all, so climate entities always used HA's own
+    device/area-based naming regardless of the configured style. There's no
+    single FHEM raw parameter name for a climate entity (it's a synthesized
+    composite of several registers), so the entity's own translation_key
+    (e.g. "heating_circuit") is used as the raw name to slugify instead.
+    """
+
+    @staticmethod
+    def _make_climate_entity(entity_id_style="default", entity_id_prefix=None):
+        from custom_components.thz.climate import THZClimate
+
+        coordinator = MagicMock()
+        coordinator.data = bytes(10)
+        coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+        device = _make_mock_device()
+        return THZClimate(
+            coordinator=coordinator,
+            cooling_coordinator=None,
+            device=device,
+            device_id="test_device",
+            translation_key="heating_circuit",
+            current_temp_offset=0,
+            current_temp_length=2,
+            target_temp_offset=2,
+            target_temp_length=2,
+            op_mode_offset=4,
+            op_mode_length=1,
+            heat_setpoint_entry=None,
+            cool_switch_entry=None,
+            cool_setpoint_entry=None,
+            entity_id_style=entity_id_style,
+            entity_id_prefix=entity_id_prefix,
+        )
+
+    def test_climate_default_style_leaves_entity_id_unset(self):
+        entity = self._make_climate_entity(entity_id_style="default")
+        assert entity.entity_id is None
+
+    def test_climate_fhem_style_sets_entity_id(self):
+        entity = self._make_climate_entity(entity_id_style="fhem")
+        assert entity.entity_id == "climate.heating_circuit"
+
+    def test_climate_fhem_style_with_prefix(self):
+        entity = self._make_climate_entity(entity_id_style="fhem", entity_id_prefix="lwz")
+        assert entity.entity_id == "climate.lwz_heating_circuit"
+
+
+class TestReadEntityIdStyle:
+    """sensor/binary_sensor entities honour entity_id_style."""
+
+    def test_generic_sensor_default_style_leaves_suggested_object_id_unset(self):
+        from custom_components.thz.sensor import THZGenericSensor
+
+        coordinator = MagicMock()
+        coordinator.data = bytes(10)
+        entity = THZGenericSensor(
+            coordinator,
+            entry={
+                "name": "collectorTemp",
+                "offset": 4,
+                "length": 2,
+                "decode": "hex2int",
+                "factor": 10,
+            },
+            block=bytes.fromhex("16"),
+            device_id="test_device",
+            entity_id_style="default",
+        )
+        assert entity.entity_id is None
+
+    def test_generic_sensor_fhem_style_sets_suggested_object_id(self):
+        from custom_components.thz.sensor import THZGenericSensor
+
+        coordinator = MagicMock()
+        coordinator.data = bytes(10)
+        entity = THZGenericSensor(
+            coordinator,
+            entry={
+                "name": "collectorTemp",
+                "offset": 4,
+                "length": 2,
+                "decode": "hex2int",
+                "factor": 10,
+            },
+            block=bytes.fromhex("16"),
+            device_id="test_device",
+            entity_id_style="fhem",
+        )
+        assert entity.entity_id == "sensor.collector_temp"
+
+    def test_binary_sensor_default_style_leaves_suggested_object_id_unset(self):
+        from custom_components.thz.binary_sensor import THZBinarySensor
+
+        coordinator = MagicMock()
+        coordinator.data = bytes([0x08])
+        entity = THZBinarySensor(
+            coordinator,
+            entry={
+                "name": "compressor",
+                "offset": 0,
+                "length": 1,
+                "decode": "bit3",
+                "icon": "mdi:engine",
+                "translation_key": "compressor",
+            },
+            block=bytes.fromhex("FB"),
+            device_id="test_device",
+            entity_id_style="default",
+        )
+        assert entity.entity_id is None
+
+    def test_binary_sensor_fhem_style_sets_suggested_object_id(self):
+        from custom_components.thz.binary_sensor import THZBinarySensor
+
+        coordinator = MagicMock()
+        coordinator.data = bytes([0x08])
+        entity = THZBinarySensor(
+            coordinator,
+            entry={
+                "name": "dhwPump",
+                "offset": 22,
+                "length": 1,
+                "decode": "bit0",
+                "icon": "mdi:pump",
+                "translation_key": "dhw_pump",
+            },
+            block=bytes.fromhex("FB"),
+            device_id="test_device",
+            entity_id_style="fhem",
+        )
+        assert entity.entity_id == "binary_sensor.dhw_pump"
+
+
+class TestPlatformSetupPassesEntityIdStyle:
+    """async_setup_write_platform reads entity_id_style from entry_data."""
+
+    @pytest.mark.asyncio
+    async def test_write_platform_defaults_to_default_style_when_absent(self):
+        """entry_data without 'entity_id_style' key doesn't crash and defaults safely."""
+        from custom_components.thz.platform_setup import async_setup_write_platform
+        from custom_components.thz.switch import THZSwitch
+        from custom_components.thz.const import DOMAIN
+
+        hass = MagicMock()
+        entry_id = "test_entry"
+        hass.data = {
+            DOMAIN: {
+                entry_id: {
+                    "write_manager": MagicMock(
+                        get_all_registers=MagicMock(
+                            return_value={
+                                "zPumpHC": {
+                                    "command": "0A0052",
+                                    "type": "switch",
+                                    "icon": "",
+                                }
+                            }
+                        )
+                    ),
+                    "device": _make_mock_device(),
+                    "device_id": "test_device",
+                    # deliberately no "entity_id_style" key
+                }
+            }
+        }
+        config_entry = MagicMock()
+        config_entry.entry_id = entry_id
+        config_entry.data = {}
+
+        added = []
+        async_add_entities = MagicMock(side_effect=lambda entities, *_a, **_kw: added.extend(entities))
+
+        await async_setup_write_platform(
+            hass, config_entry, async_add_entities, THZSwitch, "switch"
+        )
+
+        assert len(added) == 1
+        assert added[0].entity_id is None
+
+    @pytest.mark.asyncio
+    async def test_write_platform_creates_button_entities_without_error(self):
+        """Regression test: async_setup_write_platform always passes
+        entity_id_style/entity_visibility/entity_id_prefix to every write
+        platform's entity class, including button. THZButton.__init__ once
+        lacked these kwargs, which raised a TypeError at runtime and silently
+        killed the whole button platform (caught via live HA logs, not by
+        this test suite, since no prior test exercised button through this
+        code path)."""
+        from custom_components.thz.platform_setup import async_setup_write_platform
+        from custom_components.thz.button import THZButton
+        from custom_components.thz.const import DOMAIN
+
+        hass = MagicMock()
+        entry_id = "test_entry"
+        hass.data = {
+            DOMAIN: {
+                entry_id: {
+                    "write_manager": MagicMock(
+                        get_all_registers=MagicMock(
+                            return_value={
+                                "zResetLast10errors": {
+                                    "command": "0A0700",
+                                    "type": "button",
+                                    "icon": "",
+                                }
+                            }
+                        )
+                    ),
+                    "device": _make_mock_device(),
+                    "device_id": "test_device",
+                    "entity_id_style": "fhem",
+                    "entity_visibility": "default",
+                    "entity_id_prefix": "lwz",
+                }
+            }
+        }
+        config_entry = MagicMock()
+        config_entry.entry_id = entry_id
+        config_entry.data = {}
+
+        added = []
+        async_add_entities = MagicMock(side_effect=lambda entities, *_a, **_kw: added.extend(entities))
+
+        await async_setup_write_platform(
+            hass, config_entry, async_add_entities, THZButton, "button"
+        )
+
+        assert len(added) == 1
+        assert added[0].entity_id == "button.lwz_z_reset_last10errors"
+
+
+class TestEntityIdPrefix:
+    """entity_id_prefix (short device alias) threads through to fhem-style ids."""
+
+    def test_switch_fhem_style_with_prefix(self):
+        from custom_components.thz.switch import THZSwitch
+
+        entity = THZSwitch(
+            name="zPumpHC",
+            entry={"command": "0A0052", "type": "switch", "icon": ""},
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="fhem",
+            entity_id_prefix="lwz",
+        )
+        assert entity.entity_id == "switch.lwz_z_pump_hc"
+
+    def test_number_fhem_style_with_prefix(self):
+        from custom_components.thz.number import THZNumber
+
+        entity = THZNumber(
+            name="p99startUnschedVent",
+            entry={
+                "command": "0A0800",
+                "type": "number",
+                "icon": "",
+                "min": 0,
+                "max": 100,
+                "step": 1,
+                "unit": "",
+                "device_class": "",
+                "decode_type": "0clean",
+            },
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="fhem",
+            entity_id_prefix="lwz",
+        )
+        assert entity.entity_id == "number.lwz_p99start_unsched_vent"
+
+    def test_button_fhem_style_with_prefix(self):
+        from custom_components.thz.button import THZButton
+
+        entity = THZButton(
+            name="zResetLast10errors",
+            entry={"command": "0A0700", "type": "button", "icon": ""},
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="fhem",
+            entity_id_prefix="lwz",
+        )
+        assert entity.entity_id == "button.lwz_z_reset_last10errors"
+
+    def test_default_style_ignores_prefix(self):
+        """entity_id_prefix has no effect when entity_id_style is "default"."""
+        from custom_components.thz.switch import THZSwitch
+
+        entity = THZSwitch(
+            name="zPumpHC",
+            entry={"command": "0A0052", "type": "switch", "icon": ""},
+            device=_make_mock_device(),
+            device_id="test_device",
+            entity_id_style="default",
+            entity_id_prefix="lwz",
+        )
+        assert entity.entity_id is None
+
+    def test_schedule_time_fhem_style_with_prefix(self):
+        from custom_components.thz.time import THZScheduleTime
+
+        entry = {"command": "0A0500", "type": "schedule", "icon": "mdi:calendar-clock"}
+        start_entity = THZScheduleTime(
+            name="programHC1_Mo_0 Start",
+            base_name="programHC1_Mo_0",
+            entry=entry,
+            device=_make_mock_device(),
+            device_id="test_device",
+            time_type="start",
+            entity_id_style="fhem",
+            entity_id_prefix="lwz",
+        )
+        assert start_entity.entity_id == "time.lwz_program_hc1_mo_0_start"
+
+    def test_generic_sensor_fhem_style_with_prefix(self):
+        from custom_components.thz.sensor import THZGenericSensor
+
+        coordinator = MagicMock()
+        coordinator.data = bytes(10)
+        entity = THZGenericSensor(
+            coordinator,
+            entry={
+                "name": "collectorTemp",
+                "offset": 4,
+                "length": 2,
+                "decode": "hex2int",
+                "factor": 10,
+            },
+            block=bytes.fromhex("16"),
+            device_id="test_device",
+            entity_id_style="fhem",
+            entity_id_prefix="lwz",
+        )
+        assert entity.entity_id == "sensor.lwz_collector_temp"
+
+    def test_binary_sensor_fhem_style_with_prefix(self):
+        from custom_components.thz.binary_sensor import THZBinarySensor
+
+        coordinator = MagicMock()
+        coordinator.data = bytes([0x08])
+        entity = THZBinarySensor(
+            coordinator,
+            entry={
+                "name": "dhwPump",
+                "offset": 22,
+                "length": 1,
+                "decode": "bit0",
+                "icon": "mdi:pump",
+                "translation_key": "dhw_pump",
+            },
+            block=bytes.fromhex("FB"),
+            device_id="test_device",
+            entity_id_style="fhem",
+            entity_id_prefix="lwz",
+        )
+        assert entity.entity_id == "binary_sensor.lwz_dhw_pump"
+
+    @pytest.mark.asyncio
+    async def test_write_platform_passes_entity_id_prefix_through(self):
+        """async_setup_write_platform reads entity_id_prefix from entry_data."""
+        from custom_components.thz.platform_setup import async_setup_write_platform
+        from custom_components.thz.switch import THZSwitch
+        from custom_components.thz.const import DOMAIN
+
+        hass = MagicMock()
+        entry_id = "test_entry"
+        hass.data = {
+            DOMAIN: {
+                entry_id: {
+                    "write_manager": MagicMock(
+                        get_all_registers=MagicMock(
+                            return_value={
+                                "zPumpHC": {
+                                    "command": "0A0052",
+                                    "type": "switch",
+                                    "icon": "",
+                                }
+                            }
+                        )
+                    ),
+                    "device": _make_mock_device(),
+                    "device_id": "test_device",
+                    "entity_id_style": "fhem",
+                    "entity_id_prefix": "lwz",
+                }
+            }
+        }
+        config_entry = MagicMock()
+        config_entry.entry_id = entry_id
+        config_entry.data = {}
+
+        added = []
+        async_add_entities = MagicMock(side_effect=lambda entities, *_a, **_kw: added.extend(entities))
+
+        await async_setup_write_platform(
+            hass, config_entry, async_add_entities, THZSwitch, "switch"
+        )
+
+        assert len(added) == 1
+        assert added[0].entity_id == "switch.lwz_z_pump_hc"

--- a/tests/test_entity_visibility.py
+++ b/tests/test_entity_visibility.py
@@ -1,0 +1,115 @@
+"""Tests for the entity visibility tier (default / extended / all).
+
+Covers should_hide_entity()'s tier-gating logic, and confirms it agrees with
+should_hide_entity_by_default() for the "default" tier (backward
+compatibility -- see test_const.py for the exhaustive should_hide_entity_by_default
+test suite, which must keep passing unchanged after the classifier refactor).
+"""
+import pytest
+
+from custom_components.thz.const import (
+    ENTITY_VISIBILITY_ALL,
+    ENTITY_VISIBILITY_DEFAULT,
+    ENTITY_VISIBILITY_EXTENDED,
+    should_hide_entity,
+    should_hide_entity_by_default,
+)
+
+# Names classified "schedule" (program/time-plan entities)
+SCHEDULE_NAMES = [
+    "programDHW_Mo_0",
+    "programHC1_Tu_1",
+    "programHC2_We_2",
+    "programFan_Sa-So_0",
+]
+
+# Names classified "advanced" (HC2 and/or technical parameters/keywords)
+ADVANCED_NAMES = [
+    "flowTempHC2",
+    "p01RoomTempDayHC2",
+    "p13GradientHC1",
+    "p21Hyst1",
+    "p30integralComponent",
+    "boosterTimeoutDHW",
+    "pasteurisationInterval",
+]
+
+# Names never hidden under any tier
+VISIBLE_NAMES = [
+    "outsideTemp",
+    "flowTemp",
+    "dhwTemp",
+    "p01RoomTempDay",
+    "p04DHWsetTempDay",
+    "pOpMode",
+]
+
+
+class TestShouldHideEntityDefaultTier:
+    """"default" tier must exactly match should_hide_entity_by_default()."""
+
+    @pytest.mark.parametrize("name", SCHEDULE_NAMES + ADVANCED_NAMES)
+    def test_hidden_names_match_legacy_function(self, name):
+        assert should_hide_entity(name, ENTITY_VISIBILITY_DEFAULT) is True
+        assert should_hide_entity_by_default(name) is True
+
+    @pytest.mark.parametrize("name", VISIBLE_NAMES)
+    def test_visible_names_match_legacy_function(self, name):
+        assert should_hide_entity(name, ENTITY_VISIBILITY_DEFAULT) is False
+        assert should_hide_entity_by_default(name) is False
+
+    def test_default_is_the_implicit_default_argument(self):
+        """Omitting the visibility argument behaves like the "default" tier."""
+        for name in SCHEDULE_NAMES + ADVANCED_NAMES:
+            assert should_hide_entity(name) is True
+        for name in VISIBLE_NAMES:
+            assert should_hide_entity(name) is False
+
+
+class TestShouldHideEntityExtendedTier:
+    """"extended" tier hides ONLY schedule/program entities."""
+
+    @pytest.mark.parametrize("name", SCHEDULE_NAMES)
+    def test_schedule_names_still_hidden(self, name):
+        assert should_hide_entity(name, ENTITY_VISIBILITY_EXTENDED) is True
+
+    @pytest.mark.parametrize("name", ADVANCED_NAMES)
+    def test_advanced_names_become_visible(self, name):
+        assert should_hide_entity(name, ENTITY_VISIBILITY_EXTENDED) is False
+
+    @pytest.mark.parametrize("name", VISIBLE_NAMES)
+    def test_already_visible_names_stay_visible(self, name):
+        assert should_hide_entity(name, ENTITY_VISIBILITY_EXTENDED) is False
+
+
+class TestShouldHideEntityAllTier:
+    """"all" tier hides nothing."""
+
+    @pytest.mark.parametrize("name", SCHEDULE_NAMES + ADVANCED_NAMES + VISIBLE_NAMES)
+    def test_nothing_is_hidden(self, name):
+        assert should_hide_entity(name, ENTITY_VISIBILITY_ALL) is False
+
+
+class TestShouldHideEntityUnknownTier:
+    """An unrecognized tier value falls back to "default" behaviour."""
+
+    @pytest.mark.parametrize("name", SCHEDULE_NAMES + ADVANCED_NAMES)
+    def test_unknown_tier_hides_like_default(self, name):
+        assert should_hide_entity(name, "not_a_real_tier") is True
+
+    @pytest.mark.parametrize("name", VISIBLE_NAMES)
+    def test_unknown_tier_shows_visible_names(self, name):
+        assert should_hide_entity(name, "not_a_real_tier") is False
+
+
+class TestMixedCategoryNames:
+    """A name matching BOTH categories stays hidden under 'extended' too."""
+
+    def test_program_and_hc2_combined_name_treated_as_schedule(self):
+        # "programHC2_Mo_0" matches both "program" and "hc2" -- since it's a
+        # schedule entry, it should remain hidden under "extended" (only the
+        # bare "advanced" category becomes visible there).
+        name = "programHC2_Mo_0"
+        assert should_hide_entity(name, ENTITY_VISIBILITY_DEFAULT) is True
+        assert should_hide_entity(name, ENTITY_VISIBILITY_EXTENDED) is True
+        assert should_hide_entity(name, ENTITY_VISIBILITY_ALL) is False

--- a/tests/test_entity_visibility_migration.py
+++ b/tests/test_entity_visibility_migration.py
@@ -1,0 +1,227 @@
+"""Tests for _async_apply_entity_visibility_tier() in custom_components/thz/__init__.py.
+
+This function replaced the old one-time _async_migrate_disable_hidden_entities
+migration. Unlike a one-time migration, it re-runs whenever the configured
+entity_visibility tier differs from the tier last applied -- e.g. after the
+user changes the option via Reconfigure -- so it must retroactively bulk
+enable/disable entities already in the registry, not just gate newly created
+ones. It must never override an entity the user disabled themselves.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import custom_components.thz as thz_module
+
+# The real homeassistant.helpers.entity_registry module is mocked out in
+# conftest.py (sys.modules['homeassistant.helpers'] is a MagicMock, so
+# `from homeassistant.helpers import entity_registry as er` binds `er` to an
+# auto-created child mock). Grab that same object so tests can read/patch the
+# exact attributes __init__.py itself uses.
+er = thz_module.er
+
+
+def _entity(entity_id, unique_id, name, disabled_by=None):
+    """Build a fake entity registry entry with just the fields we read."""
+    return SimpleNamespace(
+        entity_id=entity_id,
+        unique_id=unique_id,
+        original_name=name,
+        name=None,
+        disabled_by=disabled_by,
+    )
+
+
+def _make_config_entry(data):
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.data = dict(data)
+    return entry
+
+
+def _make_hass():
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    return hass
+
+
+class TestApplyEntityVisibilityTier:
+    """Tests for _async_apply_entity_visibility_tier()."""
+
+    @pytest.mark.asyncio
+    async def test_first_run_disables_hidden_entities_only(self):
+        """A fresh entry (no prior tier recorded) disables hidden categories."""
+        hass = _make_hass()
+        config_entry = _make_config_entry({"entity_visibility": "default"})
+
+        entries = [
+            _entity("time.programhc1_mo_0_start", "thz_..._programhc1_mo_0", "programHC1_Mo_0"),
+            _entity("number.hc2_flow_setpoint", "thz_..._hc2_flow", "HC2 Flow Setpoint"),
+            _entity("number.booster_stage_1_timer", "thz_..._booster1", "Booster Stage 1 Timer"),
+            _entity("sensor.outside_temp", "thz_pxxfb_0_outside_temp", "Outside Temperature"),
+        ]
+
+        fake_ent_reg = MagicMock()
+        with (
+            patch.object(er, "async_get", return_value=fake_ent_reg),
+            patch.object(er, "async_entries_for_config_entry", return_value=entries),
+        ):
+            await thz_module._async_apply_entity_visibility_tier(hass, config_entry)
+
+        ent_reg = fake_ent_reg
+        disabled_ids = {
+            call.args[0] for call in ent_reg.async_update_entity.call_args_list
+            if call.kwargs.get("disabled_by") == er.RegistryEntryDisabler.INTEGRATION
+        }
+        assert disabled_ids == {
+            "time.programhc1_mo_0_start",
+            "number.hc2_flow_setpoint",
+            "number.booster_stage_1_timer",
+        }
+        # The plain sensor was never touched
+        assert "sensor.outside_temp" not in {
+            call.args[0] for call in ent_reg.async_update_entity.call_args_list
+        }
+
+        # Tier gets recorded so a subsequent identical run is a no-op
+        _, kwargs = hass.config_entries.async_update_entry.call_args
+        assert kwargs["data"]["_entity_visibility_applied"] == "default"
+
+    @pytest.mark.asyncio
+    async def test_same_tier_is_a_noop(self):
+        """Re-running with the same already-applied tier touches nothing."""
+        hass = _make_hass()
+        config_entry = _make_config_entry({
+            "entity_visibility": "default",
+            "_entity_visibility_applied": "default",
+        })
+
+        with (
+            patch.object(er, "async_get") as mock_async_get,
+            patch.object(er, "async_entries_for_config_entry") as mock_entries,
+        ):
+            await thz_module._async_apply_entity_visibility_tier(hass, config_entry)
+
+        mock_async_get.assert_not_called()
+        mock_entries.assert_not_called()
+        hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_retroactive_switch_to_extended_reenables_advanced_only(self):
+        """Switching default -> extended re-enables advanced params, keeps schedules hidden."""
+        hass = _make_hass()
+        config_entry = _make_config_entry({
+            "entity_visibility": "extended",
+            "_entity_visibility_applied": "default",
+        })
+
+        integration_disabled = er.RegistryEntryDisabler.INTEGRATION
+        entries = [
+            _entity(
+                "time.programhc1_mo_0_start", "thz_..._programhc1_mo_0",
+                "programHC1_Mo_0", disabled_by=integration_disabled,
+            ),
+            _entity(
+                "number.hc2_flow_setpoint", "thz_..._hc2_flow",
+                "HC2 Flow Setpoint", disabled_by=integration_disabled,
+            ),
+        ]
+
+        fake_ent_reg = MagicMock()
+        with (
+            patch.object(er, "async_get", return_value=fake_ent_reg),
+            patch.object(er, "async_entries_for_config_entry", return_value=entries),
+        ):
+            await thz_module._async_apply_entity_visibility_tier(hass, config_entry)
+
+        ent_reg = fake_ent_reg
+        calls = {call.args[0]: call.kwargs.get("disabled_by") for call in ent_reg.async_update_entity.call_args_list}
+
+        # HC2 (advanced) gets re-enabled under "extended"
+        assert calls.get("number.hc2_flow_setpoint") is None
+        # The schedule entry is already correctly disabled under "extended"
+        # (schedules only show under "all"), so it needs no registry update
+        # at all -- confirming the reconciliation doesn't touch entities that
+        # are already in the right state.
+        assert "time.programhc1_mo_0_start" not in calls
+
+    @pytest.mark.asyncio
+    async def test_never_touches_user_disabled_entity(self):
+        """An entity the user disabled themselves must never be re-enabled."""
+        hass = _make_hass()
+        config_entry = _make_config_entry({
+            "entity_visibility": "all",
+            "_entity_visibility_applied": "default",
+        })
+
+        user_disabled = MagicMock(name="USER_disabler_sentinel")
+        # Ensure this sentinel is distinguishable from INTEGRATION's sentinel
+        assert user_disabled != er.RegistryEntryDisabler.INTEGRATION
+
+        entries = [
+            _entity(
+                "time.programhc1_mo_0_start", "thz_..._programhc1_mo_0",
+                "programHC1_Mo_0", disabled_by=user_disabled,
+            ),
+        ]
+
+        fake_ent_reg = MagicMock()
+        with (
+            patch.object(er, "async_get", return_value=fake_ent_reg),
+            patch.object(er, "async_entries_for_config_entry", return_value=entries),
+        ):
+            await thz_module._async_apply_entity_visibility_tier(hass, config_entry)
+
+        ent_reg = fake_ent_reg
+        ent_reg.async_update_entity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_legacy_migrated_flag_treated_as_default_tier_applied(self):
+        """A pre-existing _hidden_entities_migrated=True entry with visibility
+        still 'default' is treated as already reconciled -- no-op."""
+        hass = _make_hass()
+        config_entry = _make_config_entry({
+            "entity_visibility": "default",
+            "_hidden_entities_migrated": True,
+        })
+
+        with (
+            patch.object(er, "async_get") as mock_async_get,
+            patch.object(er, "async_entries_for_config_entry") as mock_entries,
+        ):
+            await thz_module._async_apply_entity_visibility_tier(hass, config_entry)
+
+        mock_async_get.assert_not_called()
+        mock_entries.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_legacy_migrated_flag_still_reconciles_on_tier_change(self):
+        """A pre-existing _hidden_entities_migrated=True entry that has since
+        been switched to 'all' must still trigger reconciliation."""
+        hass = _make_hass()
+        config_entry = _make_config_entry({
+            "entity_visibility": "all",
+            "_hidden_entities_migrated": True,
+        })
+
+        integration_disabled = er.RegistryEntryDisabler.INTEGRATION
+        entries = [
+            _entity(
+                "time.programhc1_mo_0_start", "thz_..._programhc1_mo_0",
+                "programHC1_Mo_0", disabled_by=integration_disabled,
+            ),
+        ]
+
+        fake_ent_reg = MagicMock()
+        with (
+            patch.object(er, "async_get", return_value=fake_ent_reg),
+            patch.object(er, "async_entries_for_config_entry", return_value=entries),
+        ):
+            await thz_module._async_apply_entity_visibility_tier(hass, config_entry)
+
+        ent_reg = fake_ent_reg
+        ent_reg.async_update_entity.assert_called_once_with(
+            "time.programhc1_mo_0_start", disabled_by=None
+        )


### PR DESCRIPTION
Two related config-flow options, developed together and sharing the same entity-creation infrastructure:

entity_id_style ("default"/"fhem"): lets a new entity's entity_id be derived from its raw internal register-map/parameter name (which, for most entries, already matches FHEM's own 00_THZ.pm field name or Stiebel Eltron's official parameter number) instead of this integration's descriptive naming. Purely cosmetic — only affects suggested_object_id for brand-new entities, never unique_id or the displayed name, so switching it never renames or breaks an existing entity. An optional alias field adds a short device prefix (e.g. "lwz_p99start_unsched_vent").

entity_visibility ("default"/"extended"/"all"): controls how many HC2/schedule/advanced-parameter entities start enabled, replacing the old one-time _async_migrate_disable_hidden_entities migration with _async_apply_entity_visibility_tier, which retroactively bulk enables/disables entities when the tier is changed later via Reconfigure, without touching anything a user has toggled by hand.

Also included (developed alongside these, same commits in the source history):
- The actual entity-id-setting mechanism: Home Assistant has no "_attr_suggested_object_id" hook — Entity.suggested_object_id is a read-only @property. Setting self.entity_id directly before the entity is added to hass is the real supported mechanism; wired through every platform (sensor/binary_sensor/number/switch/select/time/button/climate).
- Orphaned-entity cleanup fix: HA's config-entry deletion can leave a dangling config_entry_id instead of nulling it, letting a stale entity registry row (with its old suggested_object_id) reattach forever on every reinstall. Now also treats a config_entry_id pointing at a since-deleted entry as orphaned, not just config_entry_id=None.

NOT included: CHANGELOG.md/README.md updates (fork-specific bookkeeping, consistent with every other PR from this fork).

 ## DO NOT MERGE YET 
 climate.py's entity_id_style/entity_id_prefix wiring touches the same THZClimate.__init__ signature and the same three HC1/HC2/DHW constructor call sites in async_setup_entry as three other open PRs from this fork:
  - fix/climate-manual-setpoint #147
  - fix/climate-mode-preset-controls #145 

This PR is built cleanly against current main and has no conflicts with main as-is, but will need a rebase once any of the above merge first. Please hold merging this until those land.

Local suite: 612 passed, 29 failed (same 29 pre-existing failures already on upstream/main — verified as an exact failure-set match via diff, not just count). 169 new tests, 0 regressions.